### PR TITLE
A few fixes cray-etcd-backup and cray-etcd-operator to get restores working

### DIFF
--- a/charts/cray-etcd-backup/Chart.yaml
+++ b/charts/cray-etcd-backup/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-etcd-backup
-version: 0.4.0
+version: 0.4.1
 description: Configures etcd cluster backups
 home: https://github.com/Cray-HPE/cray-etcd
 maintainers:

--- a/charts/cray-etcd-backup/files/list_backups
+++ b/charts/cray-etcd-backup/files/list_backups
@@ -15,9 +15,12 @@ def main():
     s3 = boto3.client('s3', endpoint_url=s3_endpoint)
 
     response = s3.list_objects_v2(Bucket=backup_bucket)
-    for item in response['Contents']:
-        if args.project in item['Key']:
-            print(item['Key'])
+    if 'Contents' in response:
+        for item in response['Contents']:
+            if args.project in item['Key']:
+                print(item['Key'])
+    else:
+        print("No backups available yet.")
 
 if __name__ == '__main__':
     main()

--- a/charts/cray-etcd-operator/Chart.yaml
+++ b/charts/cray-etcd-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-etcd-operator
-version: 0.17.0
+version: 0.17.1
 description: An extension of the official etcd-operator helm chart
 home: https://github.com/Cray-HPE/cray-etcd
 dependencies:
@@ -11,13 +11,13 @@ maintainers:
   - name: bklei
   - name: brantk-hpe
   - name: kimjensen-hpe
-appVersion: 0.12.3-cray
+appVersion: 0.12.4-cray
 annotations:
   artifacthub.io/images: |
     - name: kubectl
       image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
     - name: etcd-operator
-      image: artifactory.algol60.net/csm-docker/stable/etcd-operator:0.12.3-cray
+      image: artifactory.algol60.net/csm-docker/stable/etcd-operator:0.12.4-cray
     - name: etcd
       image: artifactory.algol60.net/csm-docker/stable/quay.io/coreos/etcd:v3.3.22
     - name: busybox

--- a/charts/cray-etcd-operator/templates/wait-jobs.yaml
+++ b/charts/cray-etcd-operator/templates/wait-jobs.yaml
@@ -27,4 +27,4 @@ spec:
             - '/bin/sh'
           args:
             - '-c'
-            - 'kubectl rollout status deployment -n operators cray-etcd-operator-etcd-operator-etcd-backup-operator cray-etcd-operator-etcd-operator-etcd-operator cray-etcd-operator-etcd-operator-etcd-restore-operator --timeout=15m'
+            - 'kubectl rollout status deployment -n operators cray-etcd-operator-etcd-operator-etcd-backup-operator; kubectl rollout status deployment -n operators cray-etcd-operator-etcd-operator-etcd-operator; kubectl rollout status deployment -n operators  cray-etcd-operator-etcd-operator-etcd-restore-operator'

--- a/charts/cray-etcd-operator/values.yaml
+++ b/charts/cray-etcd-operator/values.yaml
@@ -14,21 +14,21 @@ etcd-operator:
       cluster-wide: true
     image:
       repository: artifactory.algol60.net/csm-docker/stable/etcd-operator
-      tag: 0.12.3-cray
+      tag: 0.12.4-cray
 
   restoreOperator:
     commandArgs:
       cluster-wide: true
     image:
       repository: artifactory.algol60.net/csm-docker/stable/etcd-operator
-      tag: 0.12.3-cray
+      tag: 0.12.4-cray
 
   backupOperator:
     commandArgs:
       cluster-wide: true
     image:
       repository: artifactory.algol60.net/csm-docker/stable/etcd-operator
-      tag: 0.12.3-cray
+      tag: 0.12.4-cray
     resources:
       cpu: 100m
       memory: 512Mi


### PR DESCRIPTION
* Bring in 0.12.4-cray docker image (curl image fix)
* Fix wait for job
* Fix list script when no backups available yet

## Summary and Scope

(necessary to get etcd cluster restores working again in 1.2)

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-3640](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3640)

## Testing

vshasta -- tested period backups and restores of cray-bss and cray-bos etcd clusters

### Tested on:

  * `vshasta`

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low -- already broken

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable