### PR TITLE
Pin curl image to specific version

### DIFF
--- a/charts/cray-etcd-operator/Chart.yaml
+++ b/charts/cray-etcd-operator/Chart.yaml
@@ -1,6 +1,29 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 apiVersion: v2
 name: cray-etcd-operator
-version: 0.17.1
+version: 0.17.2
 description: An extension of the official etcd-operator helm chart
 home: https://github.com/Cray-HPE/cray-etcd
 dependencies:

--- a/charts/cray-etcd-operator/values.yaml
+++ b/charts/cray-etcd-operator/values.yaml
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 # Default values for cray-etcd-operator.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
@@ -14,21 +37,21 @@ etcd-operator:
       cluster-wide: true
     image:
       repository: artifactory.algol60.net/csm-docker/stable/etcd-operator
-      tag: 0.12.4-cray
+      tag: 0.12.5-cray
 
   restoreOperator:
     commandArgs:
       cluster-wide: true
     image:
       repository: artifactory.algol60.net/csm-docker/stable/etcd-operator
-      tag: 0.12.4-cray
+      tag: 0.12.5-cray
 
   backupOperator:
     commandArgs:
       cluster-wide: true
     image:
       repository: artifactory.algol60.net/csm-docker/stable/etcd-operator
-      tag: 0.12.4-cray
+      tag: 0.12.5-cray
     resources:
       cpu: 100m
       memory: 512Mi


### PR DESCRIPTION
## Summary and Scope

Pull in new etcd operator image pinning to specific version of curl.

## Issues and Related PRs

* Resolves [CASMTRIAGE-3194](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3194)

## Testing

```
  Normal   Pulling           16s                kubelet            Pulling image "curlimages/curl:7.73.0"
  Normal   Pulled            15s                kubelet            Successfully pulled image "curlimages/curl:7.73.0" in 903.549441ms
```

### Tested on:

  * `vshasta`

### Test description:

Used the updated operator image with pinned version, was able to pull the image during restore.

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
