### PR TITLE
Pass curl image to etcd operator via values.yaml

### DIFF
--- a/charts/cray-etcd-operator/Chart.yaml
+++ b/charts/cray-etcd-operator/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-etcd-operator
-version: 0.17.2
+version: 0.17.3
 description: An extension of the official etcd-operator helm chart
 home: https://github.com/Cray-HPE/cray-etcd
 dependencies:
@@ -32,17 +32,18 @@ dependencies:
     repository: https://charts.helm.sh/stable
 maintainers:
   - name: bklei
-  - name: brantk-hpe
   - name: kimjensen-hpe
-appVersion: 0.12.4-cray
+appVersion: 0.12.6-cray
 annotations:
   artifacthub.io/images: |
     - name: kubectl
       image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
     - name: etcd-operator
-      image: artifactory.algol60.net/csm-docker/stable/etcd-operator:0.12.4-cray
+      image: artifactory.algol60.net/csm-docker/stable/etcd-operator:0.12.6-cray
     - name: etcd
       image: artifactory.algol60.net/csm-docker/stable/quay.io/coreos/etcd:v3.3.22
     - name: busybox
       image: artifactory.algol60.net/csm-docker/stable/docker.io/library/busybox:1.28.0-glibc
+    - name: curl
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/curlimages/curl:7.73.0
   artifacthub.io/license: MIT

--- a/charts/cray-etcd-operator/values.yaml
+++ b/charts/cray-etcd-operator/values.yaml
@@ -37,21 +37,22 @@ etcd-operator:
       cluster-wide: true
     image:
       repository: artifactory.algol60.net/csm-docker/stable/etcd-operator
-      tag: 0.12.5-cray
+      tag: 0.12.6-cray
 
   restoreOperator:
     commandArgs:
       cluster-wide: true
+      curl-image: artifactory.algol60.net/csm-docker/stable/docker.io/curlimages/curl:7.73.0
     image:
       repository: artifactory.algol60.net/csm-docker/stable/etcd-operator
-      tag: 0.12.5-cray
+      tag: 0.12.6-cray
 
   backupOperator:
     commandArgs:
       cluster-wide: true
     image:
       repository: artifactory.algol60.net/csm-docker/stable/etcd-operator
-      tag: 0.12.5-cray
+      tag: 0.12.6-cray
     resources:
       cpu: 100m
       memory: 512Mi


### PR DESCRIPTION
## Summary and Scope

Finally refactor the etcd operator code such that we can pass in the curl docker image from our chart, eliminating the hard-coding of the image in the operator.

## Issues and Related PRs

* Resolves [CASMINST-4465](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4465)

## Testing

Controller startup/restore logs:
```
time="2022-04-18T20:13:25Z" level=info msg="Go Version: go1.15.7"
time="2022-04-18T20:13:25Z" level=info msg="Go OS/Arch: linux/amd64"
time="2022-04-18T20:13:25Z" level=info msg="etcd-restore-operator Version: 0.12.6-cray"
time="2022-04-18T20:13:25Z" level=info msg="Git SHA: 0f4c7639"
time="2022-04-18T20:13:25Z" level=info msg="Curl image version: artifactory.algol60.net/csm-docker/stable/docker.io/curlimages/curl:7.73.0"
.
.
time="2022-04-18T20:15:13Z" level=info msg="serving backup for restore CR cray-bss-etcd"
```

Successful restore pod using new image:
```
cray-bss-etcd-74nhj9cwfk                                          1/1     Running            0          52s
cray-bss-etcd-g7g7qlvp4s                                          1/1     Running            0          102s
cray-bss-etcd-z57n2rwz99                                          1/1     Running            0          84s
.
.
ncn-m001-990dc214:/home/bklein # kubectl get po -n services cray-bss-etcd-g7g7qlvp4s -o yaml | grep ' image.*curl:7'
    image: artifactory.algol60.net/csm-docker/stable/docker.io/curlimages/curl:7.73.0
```

### Tested on:

  * `vshasta`

### Test description:

Deploy chart with updated values.yaml and new operator image.

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
