### PR TITLE
Add cray-uas-mgr to etcd backup list

### DIFF
--- a/charts/cray-etcd-backup/Chart.yaml
+++ b/charts/cray-etcd-backup/Chart.yaml
@@ -1,11 +1,33 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 apiVersion: v2
 name: cray-etcd-backup
-version: 0.4.1
+version: 0.4.2
 description: Configures etcd cluster backups
 home: https://github.com/Cray-HPE/cray-etcd
 maintainers:
   - name: bklei
-  - name: brantk-hpe
   - name: kimjensen-hpe
 annotations:
   artifacthub.io/images: |

--- a/charts/cray-etcd-backup/files/create_backup
+++ b/charts/cray-etcd-backup/files/create_backup
@@ -1,5 +1,27 @@
 #!/bin/sh
-# Copyright 2020, Cray Inc. All Rights Reserved.
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 
 project=$1
 backup_name=$2
@@ -23,7 +45,7 @@ if [ $rc -ne 0 ]; then
     exit 1
 fi
 
-if [ $tls_secret != "" ]; then
+if [[ -n "$tls_secret" ]]; then
 
 cat > $file <<EOF
 apiVersion: "etcd.database.coreos.com/v1beta2"

--- a/charts/cray-etcd-backup/templates/configmap.yaml
+++ b/charts/cray-etcd-backup/templates/configmap.yaml
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -36,8 +59,8 @@ data:
     cray-bos.services.86400.7.
     cray-bss.services.86400.7.
     cray-crus.services.86400.7.
-    cray-externaldns.services.86400.7.
     cray-fas.services.86400.7.
+    cray-uas-mgr.services.86400.7.
 
   create_periodic_backups.sh: |-
     {{- .Files.Get "files/create_periodic_backups.sh" | nindent 4 }}


### PR DESCRIPTION
## Summary and Scope

Also remove externaldns backup -- no longer there, and fix benign but confusing shell error when creating manual backup.

## Issues and Related PRs

* Resolves [CASMPET-5638](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5638)

## Testing

```
ncn-m001-fec36008:/opt/cray/platform-utils/s3 # ./list-objects.py --bucket-name etcd-backup | grep uas
cray-uas-mgr/etcd.backup_v10_2022-05-17-16:14:09
cray-uas-mgr/etcd.backup_v10_2022-05-17-16:15:09
cray-uas-mgr/etcd.backup_v10_2022-05-17-16:16:09
cray-uas-mgr/etcd.backup_v10_2022-05-17-16:17:09
cray-uas-mgr/etcd.backup_v10_2022-05-17-16:18:09
cray-uas-mgr/etcd.backup_v10_2022-05-17-16:19:09
cray-uas-mgr/etcd.backup_v10_2022-05-17-16:20:09
```

```
ncn-m001-fec36008:/home/bklein # kubectl exec -it -n operators $(kubectl get pod -n operators | grep etcd-backup-restore | head -1 | awk '{print $1}') -c util -- restore_from_backup cray-uas-mgr etcd.backup_v10_2022-05-17-16:19:09
etcdrestore.etcd.database.coreos.com/cray-uas-mgr-etcd created
```

```
cray-uas-mgr-5d859f48d6-pbmxg                                     2/2     Running            84         21d
cray-uas-mgr-5d859f48d6-zkf2p                                     2/2     Running            79         21d
cray-uas-mgr-etcd-9k4z9slrgl                                      1/1     Running            0          47s
cray-uas-mgr-etcd-rb9z6nsdr4                                      1/1     Running            0          2m7s
cray-uas-mgr-etcd-szc6mvg9cs                                      1/1     Running            0          2m45s
```

```
ncn-m001-fec36008:/home/bklein # kubectl exec -it -n operators $(kubectl get pod -n operators | grep etcd-backup-restore | head -1 | awk '{print $1}') -c util -- create_backup cray-uas-mgr bradley-was-here
etcdbackup.etcd.database.coreos.com/cray-uas-mgr-etcd-cluster-manual-backup-30496 created
```

```
ncn-m001-fec36008:/home/bklein # kubectl exec -it -n operators $(kubectl get pod -n operators | grep etcd-backup-restore | head -1 | awk '{print $1}') -c util -- restore_from_backup cray-uas-mgr bradley-was-here
etcdrestore.etcd.database.coreos.com/cray-uas-mgr-etcd created
```

### Tested on:

  * Virtual Shasta

### Test description:

Watched autobackups get taken, restored from one of those (good).  Took manual backup and restored from one of those (good).

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable