### PR TITLE
CASMTRIAGE-4188 master : LANL DDR5 tycho bos etcd backup has not run for 9 days

### DIFF
--- a/charts/cray-etcd-backup/Chart.yaml
+++ b/charts/cray-etcd-backup/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-etcd-backup
-version: 0.4.2
+version: 0.4.3
 description: Configures etcd cluster backups
 home: https://github.com/Cray-HPE/cray-etcd
 maintainers:

--- a/charts/cray-etcd-backup/files/create_backup
+++ b/charts/cray-etcd-backup/files/create_backup
@@ -63,6 +63,8 @@ spec:
     awsSecret: etcd-backup-restore-aws-config
     forcePathStyle: true
     endpoint: $s3_endpoint
+  backupPolicy:
+    timeoutInSecond: 600
 EOF
 
 else
@@ -81,6 +83,8 @@ spec:
     awsSecret: etcd-backup-restore-aws-config
     forcePathStyle: true
     endpoint: $s3_endpoint
+  backupPolicy:
+    timeoutInSecond: 600
 EOF
 
 fi

--- a/charts/cray-etcd-backup/files/create_periodic_backups.sh
+++ b/charts/cray-etcd-backup/files/create_periodic_backups.sh
@@ -32,6 +32,7 @@ spec:
   backupPolicy:
     backupIntervalInSecond: $seconds
     maxBackups: $num_backups
+    timeoutInSecond: 600
   s3:
     path: etcd-backup/$project/etcd.backup
     awsSecret: etcd-backup-restore-aws-config
@@ -51,6 +52,7 @@ spec:
   etcdEndpoints: [http://$ip:2379]
   storageType: S3
   backupPolicy:
+    timeoutInSecond: 600
     backupIntervalInSecond: $seconds
     maxBackups: $num_backups
   s3:

--- a/charts/cray-etcd-backup/templates/clusterrole.yaml
+++ b/charts/cray-etcd-backup/templates/clusterrole.yaml
@@ -12,7 +12,7 @@ rules:
     verbs: [list, get]
   - apiGroups: ["etcd.database.coreos.com"]
     resources: [etcdbackups]
-    verbs: [get, create, patch]
+    verbs: [get, create, patch, list, delete]
   - apiGroups: ["etcd.database.coreos.com"]
     resources: [etcdrestores]
     verbs: [get, create]

--- a/charts/cray-etcd-backup/templates/post-upgrade.yaml
+++ b/charts/cray-etcd-backup/templates/post-upgrade.yaml
@@ -1,0 +1,67 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+{{/*
+This deletes all the etcdbackups resources after an upgrade to allow for 
+the objects to get re-created at the top of the hour by the cronjob 
+kube-etcd-periodic-backup-cron. This is needed to pick up the etcdbackups 
+change to add backupPolicy.timeoutInSecond: 600
+
+This can be removed in a later release if no changes to the etcdbackups are
+needed.
+
+No pre or post-rollback hook is defined because on rollback, the hooks in 
+the target release are applied. Since the previous release does not contain
+and such hooks, nothing can be done to delete the etcdbackups resources on rollback.
+https://github.com/helm/helm/issues/5825
+*/}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "cray-etcd-backup.fullname" . }}-post-upgrade-hook
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+spec:
+  template:
+    metadata:
+      name: {{ template "cray-etcd-backup.fullname" . }}-post-upgrade-hook
+    spec:
+      serviceAccountName: etcd-backup-restore
+      restartPolicy: Never
+      containers:
+        - name: post-upgrade-hook
+          image: {{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}
+          imagePullPolicy: {{ .Values.kubectl.image.pullPolicy }}
+          command:
+            - kubectl
+            - delete
+            - etcdbackups
+            - -n
+            - services
+            - --all
+          securityContext:
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534


### PR DESCRIPTION
## Summary and Scope

In LANL tycho enviromment, the bos etcd backups had been timing out for many days.
This environment has 14 workers, 2688 compute nodes in 11 Olympus cabinets.
The default timeout is 1 min, once the timeout was increased, the backups started to succeed.
The timeout was increased to 10 min for all etcdbackups and a post-upgrade hook was added to allow for the etcdbackup resources to get re-created with the added backupPolicy.timeoutInSecond value.

This is targeted for CSM 1.3.
A troubleshooting doc change will be made for CSM 1.2.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-4188](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4188)
* Change will also be needed in `<insert branch name here>`
* Future work required in N/A
*  Documentation changes required - doc the error and WAR for csm 1.2
* Merge with/before/after `<insert PR URL here>`

## Testing

vshasta
tycho

### Tested on:

  * Virtual Shasta

### Test description:

- install, upgrade (including post-upgrade hook) and rollback
- automated backups, manual backups all completed as expected

```
$ kubectl get etcdbackup -A -o yaml |  grep -B 3 "      timeoutInSecond:"
    backupPolicy:
      backupIntervalInSecond: 60
      maxBackups: 7
      timeoutInSecond: 600
--
    backupPolicy:
      backupIntervalInSecond: 86400
      maxBackups: 7
      timeoutInSecond: 600
--
    backupPolicy:
      backupIntervalInSecond: 86400
      maxBackups: 7
      timeoutInSecond: 600

$ kubectl exec -it -n operators $(kubectl get pod -n operators | grep etcd-backup-restore | head -1 | awk '{print $1}') -c util -- grep -B 3 timeoutInSecond  /usr/local/sbin/create_backup
    forcePathStyle: true
    endpoint: $s3_endpoint
  backupPolicy:
    timeoutInSecond: 600
--
    forcePathStyle: true
    endpoint: $s3_endpoint
  backupPolicy:
    timeoutInSecond: 600
    ```

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? Y
- Was downgrade tested? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

