### PR TITLE
Remove labels allowing snapshotter pod to schedule on TDS systems

### DIFF
--- a/charts/cray-etcd-base/Chart.yaml
+++ b/charts/cray-etcd-base/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-etcd-base
-version: 1.0.4
+version: 1.0.5
 description: This chart should never be installed directly, instead it is intended to be a sub-chart.
 home: https://github.com/Cray-HPE/cray-etcd
 dependencies:

--- a/charts/cray-etcd-base/templates/migration-jobs.yaml
+++ b/charts/cray-etcd-base/templates/migration-jobs.yaml
@@ -173,6 +173,12 @@ spec:
                snapshot_dir="/snapshots/{{ include "cray-etcd-base.fullname" . }}-bitnami-etcd"
                snapshot_file="{{ include "cray-etcd-base.fullname" . }}_etcd_migration.snapshot.db"
                cluster="{{ include "cray-etcd-base.fullname" . }}"
+
+               echo "Patching snapshotter cronjob to remove labels to allow scheduling alongside etcd pods.."
+               kubectl -n ${ns} patch cronjob ${cluster}-bitnami-etcd-snapshotter --type json -p='[{"op": "remove", "path": "/spec/jobTemplate/spec/template/metadata/labels/app.kubernetes.io~1instance"}]'
+
+               kubectl -n ${ns} patch cronjob ${cluster}-bitnami-etcd-snapshotter --type json -p='[{"op": "remove", "path": "/spec/jobTemplate/spec/template/metadata/labels/app.kubernetes.io~1name"}]'
+
                kubectl get etcdbackup ${cluster}-etcd-cluster-periodic-backup -n ${ns} > /dev/null 2>&1
                if [ $? -ne 0 ]; then
                   kubectl rollout status statefulset -n "${ns}" "${cluster}-bitnami-etcd"

--- a/charts/cray-etcd-base/values.yaml
+++ b/charts/cray-etcd-base/values.yaml
@@ -63,7 +63,7 @@ etcd:
   image:
     registry: artifactory.algol60.net
     repository: csm-docker/stable/docker.io/bitnami/etcd
-    tag: 3.5.7-debian-11-r10-patch
+    tag: 3.5.7-debian-11-r0-patch
     debug: false
   pullPolicy: IfNotPresent
   fullnameOverride: ""
@@ -178,5 +178,5 @@ etcd:
 util:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker.io/demisto/boto3py3
-    tag: kubectl_v1_21_12_1.0.0.43797
+    tag: kubectl_v1_21_12_1.0.0.49259
     pullPolicy: IfNotPresent

--- a/charts/cray-etcd-migration-setup/Chart.yaml
+++ b/charts/cray-etcd-migration-setup/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-etcd-migration-setup
-version: 1.0.0
+version: 1.0.1
 description: This chart sets up various prerequisites for etcd helm chart data migration
 home: https://github.com/Cray-HPE/cray-etcd
 maintainers:

--- a/charts/cray-etcd-migration-setup/templates/rbac.yaml
+++ b/charts/cray-etcd-migration-setup/templates/rbac.yaml
@@ -42,7 +42,6 @@ rules:
   - statefulsets/scale
   - secrets
   - persistentvolumeclaims
-  - etcdbackups
   verbs:
   - "get"
   - "list"
@@ -57,6 +56,13 @@ rules:
   verbs:
   - "get"
   - "delete"
+- apiGroups:
+  - "batch"
+  resources:
+  - cronjobs
+  verbs:
+  - "get"
+  - "patch"
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Summary and Scope

The bitnami chart doesn't yet support different labels for the snapshotter and etcd pods.  Until we fix that we'll remove the common labels from the cronjob spec.

## Issues and Related PRs

* Resolves [CASMTRIAGE-4964](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4964)

## Testing

```
pod/cray-bos-bitnami-etcd-0                                           2/2     Running            0          3m18s   10.34.0.46   ncn-w003-27ff67ca   <none>           <none>
pod/cray-bos-bitnami-etcd-1                                           2/2     Running            0          4m28s   10.44.0.46   ncn-w001-b76eaea2   <none>           <none>
pod/cray-bos-bitnami-etcd-2                                           2/2     Running            0          5m51s   10.43.0.21   ncn-w002-961b961b   <none>           <none>
pod/cray-bos-bitnami-etcd-snapshotter-27961777-ggqr9                  1/2     NotReady           0          19s     10.43.0.41   ncn-w002-961b961b   <none>           <none>
```

### Tested on:

  * Virtual Shasta

### Test description:

Ensured the snapshot pod can co-exist with an etcd pod.

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

