### PR TITLE
Refactor defrag process for bitnami etcd chart

### DIFF
--- a/charts/cray-etcd-defrag/Chart.yaml
+++ b/charts/cray-etcd-defrag/Chart.yaml
@@ -1,14 +1,13 @@
 apiVersion: v2
 name: cray-etcd-defrag
-version: 0.3.0
+version: 0.4.0
 description: Defrags etcd clusters
 home: https://github.com/Cray-HPE/cray-etcd
 maintainers:
   - name: bklei
-  - name: brantk-hpe
   - name: kimjensen-hpe
 annotations:
   artifacthub.io/images: |
     - name: kubectl
-      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/demisto/boto3py3:kubectl_v1_21_12_1.0.0.49259
   artifacthub.io/license: MIT

--- a/charts/cray-etcd-defrag/files/etcd_defrag.sh
+++ b/charts/cray-etcd-defrag/files/etcd_defrag.sh
@@ -1,6 +1,27 @@
 #!/bin/sh
-# Copyright 2020 Hewlett Packard Enterprise Development LP
-
+#
+# MIT License
+#
+# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 # File: etcd_defrag.sh
 #
 # Examples:
@@ -48,17 +69,17 @@ echo "Skip defrag for: $SKIP_CLUSTER_NAME"
 
 if [ $DEFRAG_CLUSTER_NAME != "all" ]
 then
-  lines=$(kubectl get etcdcluster -A | awk '{print $1 "." $2}' | grep -v NAMESPACE | grep $DEFRAG_CLUSTER_NAME)
+  lines=$(kubectl get statefulsets.apps -A | grep bitnami-etcd | awk '{print $1 "." $2}' | grep $DEFRAG_CLUSTER_NAME)
   echo "etcd clusters found: $lines"
   for line in $lines
   do
       ns=$(echo $line | awk 'BEGIN { FS = "." } ; {print $1}')
       cluster=$(echo $line | awk 'BEGIN { FS = "." } ; {print $2}')
-      members=$(kubectl get etcdcluster -n $ns $cluster -o jsonpath='{.status.members.ready}' | sed 's/\[//g' | sed 's/\]//g')
+      members=$(kubectl get endpoints ${cluster} -n ${ns} -o jsonpath='{.subsets[*].addresses[*].targetRef.name}')
       for member in $members
       do
         echo "Defragging $member"
-        output=$(kubectl -n $ns exec -i $member -- /bin/sh -c 'ETCDCTL_API=3 etcdctl --command-timeout=600s defrag')
+        output=$(kubectl -n $ns exec -i $member -- /bin/sh -c 'etcdctl --command-timeout=600s defrag')
       done
   done
   echo "Completed"
@@ -66,20 +87,20 @@ else
   if [ $SKIP_CLUSTER_NAME != "none" ]
   then
     echo "Skipping defrag for: $SKIP_CLUSTER_NAME"
-    lines=$(kubectl get etcdcluster -A | awk '{print $1 "." $2}' | grep -v NAMESPACE | grep -v -w $SKIP_CLUSTER_NAME)
+    lines=$(kubectl get statefulsets.apps -A | grep bitnami-etcd | awk '{print $1 "." $2}' | grep -v -w $SKIP_CLUSTER_NAME)
   else
-    lines=$(kubectl get etcdcluster -A | awk '{print $1 "." $2}' | grep -v NAMESPACE)
+    lines=$(kubectl get statefulsets.apps -A | grep bitnami-etcd | awk '{print $1 "." $2}')
   fi
   for line in $lines
   do
       ns=$(echo $line | awk 'BEGIN { FS = "." } ; {print $1}')
       cluster=$(echo $line | awk 'BEGIN { FS = "." } ; {print $2}')
-      members=$(kubectl get etcdcluster -n $ns $cluster -o jsonpath='{.status.members.ready}' | sed 's/\[//g' | sed 's/\]//g')
+      members=$(kubectl get endpoints ${cluster} -n ${ns} -o jsonpath='{.subsets[*].addresses[*].targetRef.name}')
       for member in $members
       do
         echo "Defragging $member"
         if [ $cluster == "cray-vault-etcd" ]; then
-          output=$(kubectl -n $ns exec -i $member -- /bin/sh -c 'ETCDCTL_API=3 etcdctl --cacert /etc/etcdtls/operator/etcd-tls/etcd-client-ca.crt --cert /etc/etcdtls/operator/etcd-tls/etcd-client.crt --key /etc/etcdtls/operator/etcd-tls/etcd-client.key --endpoints https://localhost:2379 --command-timeout=600s defrag')
+          output=$(kubectl -n $ns exec -i $member -- /bin/sh -c 'etcdctl --cacert /etc/etcdtls/operator/etcd-tls/etcd-client-ca.crt --cert /etc/etcdtls/operator/etcd-tls/etcd-client.crt --key /etc/etcdtls/operator/etcd-tls/etcd-client.key --endpoints https://localhost:2379 --command-timeout=600s defrag')
         else
           output=$(kubectl -n $ns exec -i $member -- /bin/sh -c 'ETCDCTL_API=3 etcdctl --command-timeout=600s defrag')
         fi
@@ -87,6 +108,3 @@ else
   done
   echo "Completed"
 fi
-
-
-

--- a/charts/cray-etcd-defrag/templates/clusterrole.yaml
+++ b/charts/cray-etcd-defrag/templates/clusterrole.yaml
@@ -4,11 +4,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: etcd-defragger
 rules:
-  - apiGroups: ["etcd.database.coreos.com"]
-    resources: [etcdclusters]
+  - apiGroups: ["apps"]
+    resources: [statefulsets]
     verbs: [list, get]
   - apiGroups: [""]
-    resources: [pods]
+    resources: [pods, endpoints]
     verbs: [get]
   - apiGroups: [""]
     resources: [pods/exec]

--- a/charts/cray-etcd-defrag/templates/cronjob-single-etcd.yaml
+++ b/charts/cray-etcd-defrag/templates/cronjob-single-etcd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: "kube-etcd-defrag-{{ .Values.crayHbtdEtcdDefrag.etcdClusterName }}"

--- a/charts/cray-etcd-defrag/templates/cronjob.yaml
+++ b/charts/cray-etcd-defrag/templates/cronjob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: kube-etcd-defrag

--- a/charts/cray-etcd-defrag/values.yaml
+++ b/charts/cray-etcd-defrag/values.yaml
@@ -7,12 +7,12 @@ fullnameOverride: ""
 
 kubectl:
   image:
-    repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-    tag: 1.19.15
+    repository: artifactory.algol60.net/csm-docker/stable/docker.io/demisto/boto3py3
+    tag: kubectl_v1_21_12_1.0.0.49259
     pullPolicy: IfNotPresent
 
 crayEtcdDefrag:
-  namespace: "operators"
+  namespace: "services"
   defragCronSchedule: "0 0 * * *"
 
 crayHbtdEtcdDefrag:


### PR DESCRIPTION
### Summary and Scope

Update defrag jobs for new bitnami etcd statefulsets

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6375

### Testing

* ashton

```
pit:~/brad # kubectl logs -n services pod/kube-etcd-defrag-27973386-d5c5p
Running etcd defrag for: all
Skip defrag for: cray-hbtd-etcd
Skipping defrag for: cray-hbtd-etcd
Defragging cray-bos-bitnami-etcd-0
Defragging cray-bos-bitnami-etcd-1
Defragging cray-bos-bitnami-etcd-2
Completed
```

```
{"level":"info","ts":"2023-03-09T23:06:08.418Z","caller":"backend/backend.go:497","msg":"defragmenting","path":"/bitnami/etcd/data/member/snap/db","current-db-size-bytes":225280,"current-db-size":"225 kB","current-db-size-in-use-bytes":225280,"current-db-size-in-use":"225 kB"}
{"level":"info","ts":"2023-03-09T23:06:08.446Z","caller":"backend/backend.go:549","msg":"finished defragmenting directory","path":"/bitnami/etcd/data/member/snap/db","current-db-size-bytes-diff":-4096,"current-db-size-bytes":221184,"current-db-size":"221 kB","current-db-size-in-use-bytes-diff":-12288,"current-db-size-in-use-bytes":212992,"current-db-size-in-use":"213 kB","took":"70.172943ms"}
{"level":"info","ts":"2023-03-09T23:06:08.446Z","caller":"v3rpc/maintenance.go:96","msg":"finished defragment"}
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
