### PR TITLE
Migrate data from old operator irrespective of backup config

### DIFF
--- a/charts/cray-etcd-base/Chart.yaml
+++ b/charts/cray-etcd-base/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-etcd-base
-version: 1.0.6
+version: 1.0.7
 description: This chart should never be installed directly, instead it is intended to be a sub-chart.
 home: https://github.com/Cray-HPE/cray-etcd
 dependencies:

--- a/charts/cray-etcd-base/templates/migration-jobs.yaml
+++ b/charts/cray-etcd-base/templates/migration-jobs.yaml
@@ -68,15 +68,12 @@ spec:
                ns={{ .Release.Namespace }}
                cluster="{{ include "cray-etcd-base.fullname" . }}"
 
-               kubectl get etcdbackup ${cluster}-etcd-cluster-periodic-backup -n ${ns} > /dev/null 2>&1
-               bu_rc=$?
                kubectl get endpoints ${cluster}-etcd-client -n ${ns} -o json > /dev/null 2>&1
-               ep_rc=$?
-               if [[ $bu_rc -ne 0 || $ep_rc -ne 0 ]]; then
-                  echo "${cluster}-etcd-cluster-periodic-backup and ${cluster}-etcd-client not found, assuming upgrade to bitnami chart has been completed..."
+               if [[ $? -ne 0 ]]; then
+                  echo "${cluster}-etcd-client not found, assuming upgrade to bitnami chart has been completed..."
                   exit 0
                fi
-               echo "${cluster}-etcd-cluster-periodic-backup and ${cluster}-etcd-client found, proceeding with backup/restore..."
+               echo "${cluster}-etcd-client found, proceeding with migrating current data..."
 
                cat > /tmp/upload-snapshot.py <<EOF
                #!/usr/bin/env python3
@@ -179,18 +176,6 @@ spec:
 
                kubectl -n ${ns} patch cronjob ${cluster}-bitnami-etcd-snapshotter --type json -p='[{"op": "remove", "path": "/spec/jobTemplate/spec/template/metadata/labels/app.kubernetes.io~1name"}]'
 
-               kubectl get etcdbackup ${cluster}-etcd-cluster-periodic-backup -n ${ns} > /dev/null 2>&1
-               if [ $? -ne 0 ]; then
-                  kubectl rollout status statefulset -n "${ns}" "${cluster}-bitnami-etcd"
-                  echo "Taking initial snapshot of cluster..."
-                  kubectl exec -i -n ${ns} "${cluster}-bitnami-etcd-0" -c etcd -- /bin/sh -c "ETCD_SNAPSHOTS_DIR=$snapshot_dir /opt/bitnami/scripts/etcd/snapshot.sh"
-                  echo "Editing etcd statefulset to existing (instead of new cluster)..."
-                  kubectl set env statefulset -n "${ns}" "${cluster}-bitnami-etcd" ETCD_INITIAL_CLUSTER_STATE=existing ETCD_SNAPSHOTS_DIR=$snapshot_dir
-                  echo "${cluster}-etcd-cluster-periodic-backup not found, not restoring from previous cluster backup..."
-                  exit 0
-               fi
-               echo "${cluster}-etcd-cluster-periodic-backup found, proceeding with restore..."
-
                cat > /tmp/download-snapshot.py <<EOF
                #!/usr/bin/env python3
                
@@ -235,7 +220,19 @@ spec:
                EOF
 
                echo "Download snapshot ${snapshot_file} from ${http_s3_endpoint}..."
-               /tmp/download-snapshot.py ${http_s3_endpoint} ${snapshot_dir} ${snapshot_file}
+               /tmp/download-snapshot.py ${http_s3_endpoint} ${snapshot_dir} ${snapshot_file} 2>/dev/null
+
+               if [ $? -ne 0 ]; then
+                  echo "${snapshot_file} not found, proceeding without data migration..."
+                  kubectl rollout status statefulset -n "${ns}" "${cluster}-bitnami-etcd"
+                  echo "Taking initial snapshot of cluster..."
+                  kubectl exec -i -n ${ns} "${cluster}-bitnami-etcd-0" -c etcd -- /bin/sh -c "ETCD_SNAPSHOTS_DIR=$snapshot_dir /opt/bitnami/scripts/etcd/snapshot.sh"
+                  echo "Editing etcd statefulset to existing (instead of new cluster)..."
+                  kubectl set env statefulset -n "${ns}" "${cluster}-bitnami-etcd" ETCD_INITIAL_CLUSTER_STATE=existing ETCD_SNAPSHOTS_DIR=$snapshot_dir
+                  exit 0
+               fi
+
+               echo "${snapshot_file} found, proceeding with data migration..."
                chown 1001:1001 ${snapshot_dir}/${snapshot_file}
 
                echo "Contents of $snapshot_dir:"
@@ -260,8 +257,8 @@ spec:
                  exit 1
                fi
 
-               echo "Deleting etcdbackup CRD from previous etcd deployment..."
-               kubectl delete etcdbackup ${cluster}-etcd-cluster-periodic-backup -n ${ns}
+               echo "Deleting etcdbackup CRD from previous etcd deployment if present..."
+               kubectl delete etcdbackup ${cluster}-etcd-cluster-periodic-backup -n ${ns} 2>/dev/null
 
                echo "Taking initial snapshot of cluster to $snapshot_dir..."
                kubectl exec -i -n ${ns} "${cluster}-bitnami-etcd-0" -c etcd -- /bin/sh -c "ETCD_SNAPSHOTS_DIR=$snapshot_dir /opt/bitnami/scripts/etcd/snapshot.sh"


### PR DESCRIPTION
### Summary and Scope

Migrate data from old etcd operator cluster whenever possible.

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6428

### Testing

* vshasta

```
ncn-m001-e2e75ea1:/home/bklein # kubectl logs -n services cray-bos-pre-upgrade-etcd-backup-wbjfl -f
Creating /snapshots/cray-bos-bitnami-etcd directory for snapshots...
Changing ownership of /snapshots/cray-bos-bitnami-etcd to etcd user
cray-bos-etcd-client found, proceeding with migrating current data...
Taking snapshot from cray-bos-etcd-45ctzq6vwx...
2023-03-20 16:44:35.287502 I | clientv3: opened snapshot stream; downloading
2023-03-20 16:44:35.288638 I | clientv3: completed snapshot read; closing
Snapshot saved at snapshot.db
Copying snapshot from cray-bos-etcd-45ctzq6vwx to /tmp/cray-bos_etcd_migration.snapshot.db...
Grabbing keys and S3 endpoint from etcd-backup-s3-credentials...
Uploading snapshot cray-bos_etcd_migration.snapshot.db to http://ncn-s001-c5420247:8080...
Done!
```

```
ncn-m001-e2e75ea1:/home/bklein # kubectl logs -n services cray-bos-etcd-post-install-6q85n -f
Patching snapshotter cronjob to remove labels to allow scheduling alongside etcd pods..
cronjob.batch/cray-bos-bitnami-etcd-snapshotter patched
cronjob.batch/cray-bos-bitnami-etcd-snapshotter patched
Grabbing keys and S3 endpoint from etcd-backup-s3-credentials...
Download snapshot cray-bos_etcd_migration.snapshot.db from http://ncn-s001-c5420247:8080...
cray-bos_etcd_migration.snapshot.db found, proceeding with data migration...
Contents of /snapshots/cray-bos-bitnami-etcd:
total 207
-rw-r--r--    1 1001     1001         20512 Mar 20 16:44 cray-bos_etcd_migration.snapshot.db
-rw-------    1 1001     1001         20512 Mar 20 16:34 db-2023-03-20_16-34
-rw-------    1 1001     1001         20512 Mar 20 16:39 db-2023-03-20_16-39
-rw-r--r--    1 1001     1001         24608 Mar  2 20:25 foo
-rw-r--r--    1 1001     1001         65568 Mar  3 14:33 friday-morning
-rw-r--r--    1 1001     1001         57376 Mar 16 13:48 thursday
Scaling etcd statefulset down to zero...
statefulset.apps/cray-bos-bitnami-etcd scaled
Waiting for statefulset spec update to be observed...
statefulset rolling update complete 0 pods at revision cray-bos-bitnami-etcd-86f4fdcd89...
statefulset.apps/cray-bos-bitnami-etcd env updated
Deleting existing PVC's...
persistentvolumeclaim "data-cray-bos-bitnami-etcd-0" deleted
persistentvolumeclaim "data-cray-bos-bitnami-etcd-1" deleted
persistentvolumeclaim "data-cray-bos-bitnami-etcd-2" deleted
Scaling etcd statefulset back up to three members...
statefulset.apps/cray-bos-bitnami-etcd scaled
Waiting for statefulset spec update to be observed...
Waiting for 3 pods to be ready...
Waiting for 2 pods to be ready...
Waiting for 1 pods to be ready...
statefulset rolling update complete 3 pods at revision cray-bos-bitnami-etcd-d9d8cd89c...
Deleting etcdbackup CRD from previous etcd deployment if present...
Taking initial snapshot of cluster to /snapshots/cray-bos-bitnami-etcd...
cray-bos-bitnami-etcd-0.cray-bos-bitnami-etcd-headless.services.svc.cluster.local:2379 is healthy: successfully committed proposal: took = 5.805098ms
etcd 16:46:35.20 INFO  ==> Snapshotting the keyspace
command terminated with exit code 137
Editing etcd statefulset to no longer start from snapshot...
statefulset.apps/cray-bos-bitnami-etcd env updated
Done!
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
