### PR TITLE
Update bitnami docker image with latest (CASMPET-6365)

### DIFF
--- a/charts/cray-etcd-backup/Chart.yaml
+++ b/charts/cray-etcd-backup/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-etcd-backup
-version: 0.5.3
+version: 0.5.4
 description: Configures etcd cluster backups
 home: https://github.com/Cray-HPE/cray-etcd
 maintainers:

--- a/charts/cray-etcd-backup/files/create_backup
+++ b/charts/cray-etcd-backup/files/create_backup
@@ -24,6 +24,8 @@
 #
 
 cluster=$1
+full_cluster_name="${cluster}-bitnami-etcd"
+snapshot_dir="/snapshots/${full_cluster_name}"
 backup_name=$2
 s3_endpoint=$(cat /${HOME}/.aws/s3_endpoint)
 ns=$(kubectl get statefulsets.apps -A | grep ${cluster}-bitnami-etcd | awk '{print $1}')
@@ -34,11 +36,11 @@ if test "$#" -ne 2; then
     exit 1
 fi
 
-pods=$(kubectl get endpoints ${cluster}-bitnami-etcd -n ${ns} -o jsonpath='{.subsets[*].addresses[*].targetRef.name}')
+pods=$(kubectl get endpoints ${full_cluster_name} -n ${ns} -o jsonpath='{.subsets[*].addresses[*].targetRef.name}')
 for pod in $pods
 do
   echo "Taking snapshot from ${pod}..."
-  output=$(kubectl exec -i -n ${ns} ${pod} -c etcd -- /bin/sh -c "ETCD_SNAPSHOTS_DIR=$snapshot_dir /opt/bitnami/scripts/etcd/snapshot.sh" 2>/dev/null)
+  output=$(kubectl exec -i -n ${ns} ${pod} -c etcd -- /bin/sh -c "ETCD_SNAPSHOTS_DIR=${snapshot_dir} /opt/bitnami/scripts/etcd/snapshot.sh" 2>/dev/null)
   if [ $? -eq 0 ]; then
      new_snapshot=$(echo "$output" | grep "Snapshot saved at" | awk '{print $NF}')
      break

--- a/charts/cray-etcd-base/Chart.yaml
+++ b/charts/cray-etcd-base/Chart.yaml
@@ -23,21 +23,21 @@
 #
 apiVersion: v2
 name: cray-etcd-base
-version: 1.0.7
+version: 1.0.8
 description: This chart should never be installed directly, instead it is intended to be a sub-chart.
 home: https://github.com/Cray-HPE/cray-etcd
 dependencies:
   - name: etcd
-    version: 8.7.3
+    version: 8.8.1
     repository: https://charts.bitnami.com/bitnami
 maintainers:
   - name: bklei
 annotations:
   artifacthub.io/images: |
     - name: etcd
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/etcd:3.5.7-debian-11-r0-patch
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/etcd:3.5.7-debian-11-r22-patch
     - name: bitnami-shell
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/bitnami-shell:11-debian-11-r79
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/bitnami-shell:11-debian-11-r102
     - name: util
       image: artifactory.algol60.net/csm-docker/stable/docker.io/demisto/boto3py3:kubectl_v1_21_12_1.0.0.43797
   artifacthub.io/license: MIT

--- a/charts/cray-etcd-base/templates/migration-jobs.yaml
+++ b/charts/cray-etcd-base/templates/migration-jobs.yaml
@@ -60,7 +60,7 @@ spec:
             - "-c"
             - |
                snapshot_dir="/snapshots/{{ include "cray-etcd-base.fullname" . }}-bitnami-etcd"
-               snapshot_file="{{ include "cray-etcd-base.fullname" . }}_etcd_migration.snapshot.db"
+               snapshot_file="{{ include "cray-etcd-base.fullname" . }}_etcd_migration.snapshot-{{ .Release.Revision }}.db"
                echo "Creating $snapshot_dir directory for snapshots..."
                mkdir -p $snapshot_dir
                echo "Changing ownership of $snapshot_dir to etcd user"
@@ -168,13 +168,31 @@ spec:
             - |
                ns={{ .Release.Namespace }}
                snapshot_dir="/snapshots/{{ include "cray-etcd-base.fullname" . }}-bitnami-etcd"
-               snapshot_file="{{ include "cray-etcd-base.fullname" . }}_etcd_migration.snapshot.db"
+               snapshot_file="{{ include "cray-etcd-base.fullname" . }}_etcd_migration.snapshot-{{ .Release.Revision }}.db"
                cluster="{{ include "cray-etcd-base.fullname" . }}"
 
                echo "Patching snapshotter cronjob to remove labels to allow scheduling alongside etcd pods.."
                kubectl -n ${ns} patch cronjob ${cluster}-bitnami-etcd-snapshotter --type json -p='[{"op": "remove", "path": "/spec/jobTemplate/spec/template/metadata/labels/app.kubernetes.io~1instance"}]'
 
                kubectl -n ${ns} patch cronjob ${cluster}-bitnami-etcd-snapshotter --type json -p='[{"op": "remove", "path": "/spec/jobTemplate/spec/template/metadata/labels/app.kubernetes.io~1name"}]'
+
+               cat > /tmp/upload-snapshot.py <<EOF
+               #!/usr/bin/env python3
+
+               import boto3
+               import sys
+
+               def main():
+                   s3 = boto3.resource('s3', endpoint_url=sys.argv[1])
+                   bucket = s3.Bucket('etcd-backup')
+                   file_name="/snapshots/{{ include "cray-etcd-base.fullname" . }}-bitnami-etcd/%s" % (sys.argv[2])
+                   key_name="{{ include "cray-etcd-base.fullname" . }}/%s" % (sys.argv[2])
+                   bucket.upload_file(Filename=file_name, Key=key_name)
+
+               if __name__ == '__main__':
+                   main()
+               EOF
+               chmod 755 /tmp/upload-snapshot.py
 
                cat > /tmp/download-snapshot.py <<EOF
                #!/usr/bin/env python3
@@ -227,6 +245,9 @@ spec:
                   kubectl rollout status statefulset -n "${ns}" "${cluster}-bitnami-etcd"
                   echo "Taking initial snapshot of cluster..."
                   kubectl exec -i -n ${ns} "${cluster}-bitnami-etcd-0" -c etcd -- /bin/sh -c "ETCD_SNAPSHOTS_DIR=$snapshot_dir /opt/bitnami/scripts/etcd/snapshot.sh"
+                  snapshot_file=$(find ${snapshot_dir}/ -maxdepth 1 -type f -name 'db-*' | sort | tail -n 1 | sed 's/.*\///')
+                  echo "Uploading snapshot ${snapshot_file} to ${http_s3_endpoint}..."
+                  /tmp/upload-snapshot.py ${http_s3_endpoint} ${snapshot_file}
                   echo "Editing etcd statefulset to existing (instead of new cluster)..."
                   kubectl set env statefulset -n "${ns}" "${cluster}-bitnami-etcd" ETCD_INITIAL_CLUSTER_STATE=existing ETCD_SNAPSHOTS_DIR=$snapshot_dir
                   exit 0
@@ -262,6 +283,10 @@ spec:
 
                echo "Taking initial snapshot of cluster to $snapshot_dir..."
                kubectl exec -i -n ${ns} "${cluster}-bitnami-etcd-0" -c etcd -- /bin/sh -c "ETCD_SNAPSHOTS_DIR=$snapshot_dir /opt/bitnami/scripts/etcd/snapshot.sh"
+
+               snapshot_file=$(find ${snapshot_dir}/ -maxdepth 1 -type f -name 'db-*' | sort | tail -n 1 | sed 's/.*\///')
+               echo "Uploading snapshot ${snapshot_file} to ${http_s3_endpoint}..."
+               /tmp/upload-snapshot.py ${http_s3_endpoint} ${snapshot_file}
 
                echo "Editing etcd statefulset to no longer start from snapshot..."
 

--- a/charts/cray-etcd-base/values.yaml
+++ b/charts/cray-etcd-base/values.yaml
@@ -47,7 +47,7 @@ etcd:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/docker.io/bitnami/bitnami-shell
-      tag: 11-debian-11-r79
+      tag: 11-debian-11-r102
       digest: ""
       pullPolicy: IfNotPresent
   containerPorts:
@@ -63,7 +63,7 @@ etcd:
   image:
     registry: artifactory.algol60.net
     repository: csm-docker/stable/docker.io/bitnami/etcd
-    tag: 3.5.7-debian-11-r0-patch
+    tag: 3.5.7-debian-11-r22-patch
     debug: false
   pullPolicy: IfNotPresent
   fullnameOverride: ""
@@ -140,9 +140,10 @@ etcd:
   disasterRecovery:
     enabled: true
     cronjob:
+      snapshotsDir: "/snapshots"
       schedule: "0 */1 * * *"
       historyLimit: 1
-      snapshotHistoryLimit: 24 
+      snapshotHistoryLimit: 24
       resources:
         limits: {}
         requests: {}


### PR DESCRIPTION
### Summary and Scope

Later code for bitnami etcd chart and fixes for CLBO after power off/on.

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6365

### Testing

* `ashton`

Scale down to zero and back up to three members:

```
etcd 19:09:19.70
etcd 19:09:19.70 Welcome to the Bitnami etcd container
etcd 19:09:19.71 Subscribe to project updates by watching https://github.com/bitnami/containers
etcd 19:09:19.72 Submit issues and feature requests at https://github.com/bitnami/containers/issues
etcd 19:09:19.73
etcd 19:09:19.74 INFO  ==> ** Starting etcd setup **
etcd 19:09:19.77 INFO  ==> Validating settings in ETCD_* env vars..
etcd 19:09:19.80 WARN  ==> You set the environment variable ALLOW_NONE_AUTHENTICATION=yes. For safety reasons, do not use this flag in a production environment.
etcd 19:09:19.82 INFO  ==> Initializing etcd
etcd 19:09:19.83 INFO  ==> Generating etcd config file using env variables
etcd 19:09:19.92 INFO  ==> Detected data from previous deployments
etcd 19:09:19.94 DEBUG ==> Setting data directory permissions to 700 in a recursive way (required in etcd >=3.4.10)
etcd 19:09:20.04 DEBUG ==> There are no enough active endpoints!
etcd 19:09:20.05 WARN  ==> Cluster not responding!
etcd 19:09:20.07 INFO  ==> Restoring etcd cluster from snapshot
Deprecated: Use `etcdutl snapshot restore` instead.

2023-04-12T19:09:20Z	info	snapshot/v3_snapshot.go:248	restoring snapshot	{"path": "/snapshots/cray-bos-bitnami-etcd/db-2023-04-12_19-01", "wal-dir": "/bitnami/etcd/data/member/wal", "data-dir": "/bitnami/etcd/data", "snap-dir": "/bitnami/etcd/data/member/snap", "stack": "go.etcd.io/etcd/etcdutl/v3/snapshot.(*v3Manager).Restore\n\tgo.etcd.io/etcd/etcdutl/v3@v3.5.7/snapshot/v3_snapshot.go:254\ngo.etcd.io/etcd/etcdutl/v3/etcdutl.SnapshotRestoreCommandFunc\n\tgo.etcd.io/etcd/etcdutl/v3@v3.5.7/etcdutl/snapshot_command.go:147\ngo.etcd.io/etcd/etcdctl/v3/ctlv3/command.snapshotRestoreCommandFunc\n\tgo.etcd.io/etcd/etcdctl/v3/ctlv3/command/snapshot_command.go:129\ngithub.com/spf13/cobra.(*Command).execute\n\tgithub.com/spf13/cobra@v1.1.3/command.go:856\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\tgithub.com/spf13/cobra@v1.1.3/command.go:960\ngithub.com/spf13/cobra.(*Command).Execute\n\tgithub.com/spf13/cobra@v1.1.3/command.go:897\ngo.etcd.io/etcd/etcdctl/v3/ctlv3.Start\n\tgo.etcd.io/etcd/etcdctl/v3/ctlv3/ctl.go:107\ngo.etcd.io/etcd/etcdctl/v3/ctlv3.MustStart\n\tgo.etcd.io/etcd/etcdctl/v3/ctlv3/ctl.go:111\nmain.main\n\tgo.etcd.io/etcd/etcdctl/v3/main.go:59\nruntime.main\n\truntime/proc.go:255"}
2023-04-12T19:09:20Z	info	membership/store.go:141	Trimming membership information from the backend...
2023-04-12T19:09:20Z	info	membership/cluster.go:421	added member	{"cluster-id": "5a9864fc76d9fc6f", "local-member-id": "0", "added-peer-id": "2b4984dc5c79bd55", "added-peer-peer-urls": ["http://cray-bos-bitnami-etcd-2.cray-bos-bitnami-etcd-headless.services.svc.cluster.local:2380"]}
2023-04-12T19:09:20Z	info	membership/cluster.go:421	added member	{"cluster-id": "5a9864fc76d9fc6f", "local-member-id": "0", "added-peer-id": "6a95fcc74f1f8616", "added-peer-peer-urls": ["http://cray-bos-bitnami-etcd-1.cray-bos-bitnami-etcd-headless.services.svc.cluster.local:2380"]}
2023-04-12T19:09:20Z	info	membership/cluster.go:421	added member	{"cluster-id": "5a9864fc76d9fc6f", "local-member-id": "0", "added-peer-id": "75c23b83965f55de", "added-peer-peer-urls": ["http://cray-bos-bitnami-etcd-0.cray-bos-bitnami-etcd-headless.services.svc.cluster.local:2380"]}
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
