### PR TITLE
Increase size of common etcd snapshot PVC (CASMPET-6419)

### DIFF
--- a/charts/cray-etcd-migration-setup/Chart.yaml
+++ b/charts/cray-etcd-migration-setup/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-etcd-migration-setup
-version: 1.0.1
+version: 1.0.2
 description: This chart sets up various prerequisites for etcd helm chart data migration
 home: https://github.com/Cray-HPE/cray-etcd
 maintainers:

--- a/charts/cray-etcd-migration-setup/values.yaml
+++ b/charts/cray-etcd-migration-setup/values.yaml
@@ -22,4 +22,4 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 ---
-volumeSize: 10G
+volumeSize: 200G


### PR DESCRIPTION
### Summary and Scope

Increase size of etcd cephfs pvc for snapshots.  Going with 200G which should leave more than enough space based on audit of current usage of the etcd-backups bucket:

```
11958904 ~12G (mug)
14889340 ~14G (baldar)
17817388 ~17G (shandy)
21434928 ~21G (hela)
```

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6419

### Testing

* `ashton`

```
ncn-m002:~ # kubectl get pvc -n services bitnami-etcd-snapshotter -o json | jq -r .spec.resources.requests.storage
200G
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
