### PR TITLE
Consume upstream changes which have merged for bitnami etcd (CASMPET-6504)

### DIFF
--- a/charts/cray-etcd-base/Chart.yaml
+++ b/charts/cray-etcd-base/Chart.yaml
@@ -23,21 +23,21 @@
 #
 apiVersion: v2
 name: cray-etcd-base
-version: 1.0.8
+version: 1.0.9
 description: This chart should never be installed directly, instead it is intended to be a sub-chart.
 home: https://github.com/Cray-HPE/cray-etcd
 dependencies:
   - name: etcd
-    version: 8.8.1
+    version: 8.9.0
     repository: https://charts.bitnami.com/bitnami
 maintainers:
   - name: bklei
 annotations:
   artifacthub.io/images: |
     - name: etcd
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/etcd:3.5.7-debian-11-r22-patch
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/etcd:3.5.8-debian-11-r3
     - name: bitnami-shell
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/bitnami-shell:11-debian-11-r102
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/bitnami-shell:11-debian-11-r109
     - name: util
       image: artifactory.algol60.net/csm-docker/stable/docker.io/demisto/boto3py3:kubectl_v1_21_12_1.0.0.43797
   artifacthub.io/license: MIT

--- a/charts/cray-etcd-base/tests/etcd-enabled_test.yaml
+++ b/charts/cray-etcd-base/tests/etcd-enabled_test.yaml
@@ -300,19 +300,19 @@ tests:
           value: "true"
       - template: charts/etcd/templates/cronjob.yaml
         equal:
-          path: spec.jobTemplate.spec.template.spec.containers[0].env[6].name
+          path: spec.jobTemplate.spec.template.spec.containers[0].env[7].name
           value: "ETCD_CERT_FILE"
       - template: charts/etcd/templates/cronjob.yaml
         equal:
-          path: spec.jobTemplate.spec.template.spec.containers[0].env[6].value
+          path: spec.jobTemplate.spec.template.spec.containers[0].env[7].value
           value: "/opt/bitnami/etcd/certs/client/cert.pem"
       - template: charts/etcd/templates/cronjob.yaml
         equal:
-          path: spec.jobTemplate.spec.template.spec.containers[0].env[7].name
+          path: spec.jobTemplate.spec.template.spec.containers[0].env[8].name
           value: "ETCD_KEY_FILE"
       - template: charts/etcd/templates/cronjob.yaml
         equal:
-          path: spec.jobTemplate.spec.template.spec.containers[0].env[7].value
+          path: spec.jobTemplate.spec.template.spec.containers[0].env[8].value
           value: "/opt/bitnami/etcd/certs/client/key.pem"
       - template: charts/etcd/templates/cronjob.yaml
         equal:

--- a/charts/cray-etcd-base/values.yaml
+++ b/charts/cray-etcd-base/values.yaml
@@ -47,7 +47,7 @@ etcd:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/docker.io/bitnami/bitnami-shell
-      tag: 11-debian-11-r102
+      tag: 11-debian-11-r109
       digest: ""
       pullPolicy: IfNotPresent
   containerPorts:
@@ -63,7 +63,7 @@ etcd:
   image:
     registry: artifactory.algol60.net
     repository: csm-docker/stable/docker.io/bitnami/etcd
-    tag: 3.5.7-debian-11-r22-patch
+    tag: 3.5.8-debian-11-r3
     debug: false
   pullPolicy: IfNotPresent
   fullnameOverride: ""


### PR DESCRIPTION
### Summary and Scope

Bring in latest bitnami etcd images with upstream merges

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6504

### Testing

```
ncn-m002:~ # /opt/cray/platform-utils/etcd/etcd-util.sh create_backup cray-bos brad-manual-1
Taking snapshot from cray-bos-bitnami-etcd-1...
Pushing newly created snapshot /snapshots/cray-bos-bitnami-etcd/db-2023-04-24_18-15 to S3 as brad-manual-1 for cray-bos
upload: snapshots/cray-bos-bitnami-etcd/db-2023-04-24_18-15 to s3://etcd-backup/cray-bos/brad-manual-1
```

```
ncn-m002:~ # /opt/cray/platform-utils/etcd/etcd_restore_rebuild.sh -s cray-bos
The following etcd clusters will be restored/rebuilt:

cray-bos

You will be accepting responsibility for any missing data if there is a
restore/rebuild over a running etcd k/v. HPE assumes no responsibility.
Proceed restoring/rebuilding? (yes/no)
yes

Proceeding: restoring/rebuilding etcd clusters.

 ----- Restoring from cray-bos/brad-manual-1 -----
Downloading brad-manual-1 from S3 for cray-bos
download: s3://etcd-backup/cray-bos/brad-manual-1 to snapshots/cray-bos-bitnami-etcd/brad-manual-1
Scaling etcd statefulset down to zero...
statefulset.apps/cray-bos-bitnami-etcd scaled
statefulset rolling update complete 0 pods at revision cray-bos-bitnami-etcd-8655ddd796...
Setting cluster state for cray-bos to 'new' and to start from snapshot
statefulset.apps/cray-bos-bitnami-etcd env updated
Deleting existing PVC's...
persistentvolumeclaim "data-cray-bos-bitnami-etcd-0" deleted
persistentvolumeclaim "data-cray-bos-bitnami-etcd-1" deleted
persistentvolumeclaim "data-cray-bos-bitnami-etcd-2" deleted
Scaling etcd statefulset back up to three members...
statefulset.apps/cray-bos-bitnami-etcd scaled
waiting for statefulset rolling update to complete 0 pods at revision cray-bos-bitnami-etcd-bbc574fdc...
Waiting for 1 pods to be ready...
Waiting for 2 pods to be ready...
Waiting for 3 pods to be ready...
Waiting for 3 pods to be ready...
Waiting for 3 pods to be ready...
Waiting for 2 pods to be ready...
Waiting for 1 pods to be ready...
statefulset rolling update complete 3 pods at revision cray-bos-bitnami-etcd-bbc574fdc...
Setting cluster state for cray-bos to back to 'existing'
statefulset.apps/cray-bos-bitnami-etcd env updated

Checking endpoint health.
cray-bos etcd cluster health verified from cray-bos-bitnami-etcd-0
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
