### PR TITLE
Fix system power off/on CLBO issue with bitnami etcd pods (CASMPET-6642)

### DIFF
--- a/charts/cray-etcd-base/Chart.yaml
+++ b/charts/cray-etcd-base/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-etcd-base
-version: 1.0.9
+version: 1.0.10
 description: This chart should never be installed directly, instead it is intended to be a sub-chart.
 home: https://github.com/Cray-HPE/cray-etcd
 dependencies:
@@ -35,9 +35,9 @@ maintainers:
 annotations:
   artifacthub.io/images: |
     - name: etcd
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/etcd:3.5.8-debian-11-r3
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/etcd:3.5.9-debian-11-r15-patch
     - name: bitnami-shell
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/bitnami-shell:11-debian-11-r109
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/bitnami-shell:11-debian-11-r128
     - name: util
       image: artifactory.algol60.net/csm-docker/stable/docker.io/demisto/boto3py3:kubectl_v1_21_12_1.0.0.43797
   artifacthub.io/license: MIT

--- a/charts/cray-etcd-base/values.yaml
+++ b/charts/cray-etcd-base/values.yaml
@@ -47,7 +47,7 @@ etcd:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/docker.io/bitnami/bitnami-shell
-      tag: 11-debian-11-r109
+      tag: 11-debian-11-r128
       digest: ""
       pullPolicy: IfNotPresent
   containerPorts:
@@ -63,7 +63,7 @@ etcd:
   image:
     registry: artifactory.algol60.net
     repository: csm-docker/stable/docker.io/bitnami/etcd
-    tag: 3.5.8-debian-11-r3
+    tag: 3.5.9-debian-11-r15-patch
     debug: false
   pullPolicy: IfNotPresent
   fullnameOverride: ""
@@ -166,6 +166,8 @@ etcd:
       value: "10000"
     - name: ETCD_SNAPSHOT_HISTORY_LIMIT
       value: "24"
+    - name: ETCD_DISABLE_PRESTOP
+      value: "yes"
   podSecurityContext:
     enabled: true
     fsGroup: 1001


### PR DESCRIPTION
### Summary and Scope

New bitnami images with power off/on fix and set ETCD_DISABLE_PRESTOP option.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6642

### Testing

Tested on ashton:

After simulating power off/on, cray-bos (with this fix) was the only one to start cleanly:

```
services         cray-bos-bitnami-etcd-0                                           2/2     Running                 2 (19m ago)       38m
services         cray-bos-bitnami-etcd-1                                           2/2     Running                 3 (3m45s ago)     38m
services         cray-bos-bitnami-etcd-2                                           2/2     Running                 2 (19m ago)       38m
services         cray-bos-bitnami-etcd-snapshotter-28122840-ld7fr                  0/2     Completed               0                 78m
services         cray-bos-bitnami-etcd-snapshotter-28122900-zc5ql                  0/2     PodInitializing         0                 7m37s
services         cray-bss-bitnami-etcd-0                                           1/2     CrashLoopBackOff        4 (2m12s ago)     20h
services         cray-bss-bitnami-etcd-1                                           1/2     CrashLoopBackOff        2 (2m39s ago)     20h
services         cray-bss-bitnami-etcd-2                                           1/2     CrashLoopBackOff        5 (59s ago)       20h
```

```
etcd 18:49:49.25 Subscribe to project updates by watching https://github.com/bitnami/containers
etcd 18:49:49.26 Submit issues and feature requests at https://github.com/bitnami/containers/issues
etcd 18:49:49.26
etcd 18:49:49.27 INFO  ==> ** Starting etcd setup **
etcd 18:49:49.31 INFO  ==> Validating settings in ETCD_* env vars..
etcd 18:49:49.32 WARN  ==> You set the environment variable ALLOW_NONE_AUTHENTICATION=yes. For safety reasons, do not use this flag in a production environment.
etcd 18:49:49.34 INFO  ==> Initializing etcd
etcd 18:49:49.34 INFO  ==> Generating etcd config file using env variables
etcd 18:49:49.48 INFO  ==> Detected data from previous deployments
etcd 18:49:49.50 INFO  ==> The member will try to join the cluster by it's own
etcd 18:49:49.56 INFO  ==> ** etcd setup finished! **

etcd 18:49:49.61 INFO  ==> ** Starting etcd **
{"level":"warn","ts":"2023-06-22T18:49:49.653919Z","caller":"embed/config.go:673","msg":"Running http and grpc server on single port. This is not recommended for production."}
{"level":"info","ts":"2023-06-22T18:49:49.654191Z","caller":"etcdmain/config.go:350","msg":"loaded server configuration, other configuration command line flags and environment variables will be ignored if provided","path":"/opt/bitnami/etcd/conf/etcd.yaml"}
{"level":"info","ts":"2023-06-22T18:49:49.654213Z","caller":"etcdmain/etcd.go:73","msg":"Running: ","args":["etcd","--config-file","/opt/bitnami/etcd/conf/etcd.yaml"]}
{"level":"info","ts":"2023-06-22T18:49:49.654298Z","caller":"etcdmain/etcd.go:116","msg":"server has been already initialized","data-dir":"/bitnami/etcd/data","dir-type":"member"}
{"level":"warn","ts":"2023-06-22T18:49:49.65435Z","caller":"embed/config.go:673","msg":"Running http and grpc server on single port. This is not recommended for production."}
{"level":"info","ts":"2023-06-22T18:49:49.654364Z","caller":"embed/etcd.go:127","msg":"configuring peer listeners","listen-peer-urls":["http://0.0.0.0:2380"]}
{"level":"info","ts":"2023-06-22T18:49:49.654576Z","caller":"embed/etcd.go:135","msg":"configuring client listeners","listen-client-urls":["http://0.0.0.0:2379"]}
{"level":"info","ts":"2023-06-22T18:49:49.654686Z","caller":"embed/etcd.go:309","msg":"starting an etcd server","etcd-version":"3.5.9","git-sha":"bdbbde998","go-version":"go1.19.9","go-os":"linux","go-arch":"amd64","max-cpu-set":24,"max-cpu-available":24,"member-initialized":true,"name":"cray-bos-bitnami-etcd-1","data-dir":"/bitnami/etcd/data","wal-dir":"","wal-dir-dedicated":"","member-dir":"/bitnami/etcd/data/member","force-new-cluster":false,"heartbeat-interval":"100ms","election-timeout":"1s","initial-election-tick-advance":true,"snapshot-count":100000,"max-wals":5,"max-snapshots":5,"snapshot-catchup-entries":5000,"initial-advertise-peer-urls":["http://cray-bos-bitnami-etcd-1.cray-bos-bitnami-etcd-headless.services.svc.cluster.local:2380"],"listen-peer-urls":["http://0.0.0.0:2380"],"advertise-client-urls":["http://cray-bos-bitnami-etcd-1.cray-bos-bitnami-etcd-headless.services.svc.cluster.local:2379"],"listen-client-urls":["http://0.0.0.0:2379"],"listen-metrics-urls":[],"cors":["*"],"host-whitelist":["*"],"initial-cluster":"","initial-cluster-state":"new","initial-cluster-token":"","quota-backend-bytes":2147483648,"max-request-bytes":1572864,"max-concurrent-streams":4294967295,"pre-vote":true,"initial-corrupt-check":false,"corrupt-check-time-interval":"0s","compact-check-time-enabled":false,"compact-check-time-interval":"1m0s","auto-compaction-mode":"","auto-compaction-retention":"0s","auto-compaction-interval":"0s","discovery-url":"","discovery-proxy":"","downgrade-check-interval":"5s"}
```

```
ncn-m002:~ # /opt/cray/platform-utils/etcd/etcd-util.sh endpoint_status cray-bos
### cray-bos-bitnami-etcd-0 Endpoint Status: ###
+----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
|    ENDPOINT    |        ID        | VERSION | DB SIZE | IS LEADER | IS LEARNER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS |
+----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
| 127.0.0.1:2379 | 75c23b83965f55de |   3.5.9 |  1.2 MB |      true |      false |        14 |      83862 |              83862 |        |
+----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
### cray-bos-bitnami-etcd-1 Endpoint Status: ###
+----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
|    ENDPOINT    |        ID        | VERSION | DB SIZE | IS LEADER | IS LEARNER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS |
+----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
| 127.0.0.1:2379 | 6a95fcc74f1f8616 |   3.5.9 |  1.3 MB |     false |      false |        14 |      83862 |              83862 |        |
+----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
### cray-bos-bitnami-etcd-2 Endpoint Status: ###
+----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
|    ENDPOINT    |        ID        | VERSION | DB SIZE | IS LEADER | IS LEARNER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS |
+----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
| 127.0.0.1:2379 | 2b4984dc5c79bd55 |   3.5.9 |  1.2 MB |     false |      false |        14 |      83862 |              83862 |        |
+----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
