### PR TITLE
Populate etcd config file with env vars (CASMINST-6572)

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -23,11 +23,14 @@ pipeline {
                     getChartVersion(name: "cray-etcd-backup",          chartDirectory: "charts", isStable: env.IS_STABLE),
                     getChartVersion(name: "cray-etcd-defrag",          chartDirectory: "charts", isStable: env.IS_STABLE),
                     getChartVersion(name: "cray-etcd-base",            chartDirectory: "charts", isStable: env.IS_STABLE),
-                    getChartVersion(name: "cray-etcd-migration-setup", chartDirectory: "charts", isStable: env.IS_STABLE)
+                    getChartVersion(name: "cray-etcd-migration-setup", chartDirectory: "charts", isStable: env.IS_STABLE),
+                    getChartVersion(name: "cray-etcd-test",            chartDirectory: "charts", isStable: env.IS_STABLE)
                 ].join(" ")
             }
             steps {
-                sh "make"
+                 withCredentials([usernamePassword(credentialsId: 'artifactory-algol60-readonly', passwordVariable: 'ARTIFACTORY_PASSWORD', usernameVariable: 'ARTIFACTORY_USERNAME')]) {
+                    sh "make"
+                }
             }
         }
 

--- a/charts/cray-etcd-base/Chart.yaml
+++ b/charts/cray-etcd-base/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-etcd-base
-version: 1.0.10
+version: 1.0.11
 description: This chart should never be installed directly, instead it is intended to be a sub-chart.
 home: https://github.com/Cray-HPE/cray-etcd
 dependencies:

--- a/charts/cray-etcd-base/templates/configmap.yaml
+++ b/charts/cray-etcd-base/templates/configmap.yaml
@@ -50,3 +50,8 @@ data:
     advertise-client-urls: {{ printf "%s://POD_NAME.%s.%s.svc.%s:%d" $etcdPeerProtocol $etcdHeadlessServiceName $releaseNamespace $clusterDomain $clientPort }}
     listen-client-urls: http://0.0.0.0:{{ $clientPort }}
     data-dir: /bitnami/etcd/data
+{{- if .Values.etcd.extraEnvVars }}
+{{- range $key, $value := .Values.etcd.extraEnvVars }}
+{{ index $value "name" | replace "ETCD_" "" | replace "_" "-" | lower | indent 4 }}: {{ index $value "value" }}
+{{- end }}
+{{- end }}

--- a/charts/cray-etcd-test/.gitignore
+++ b/charts/cray-etcd-test/.gitignore
@@ -1,0 +1,2 @@
+*.lock
+charts

--- a/charts/cray-etcd-test/Chart.yaml
+++ b/charts/cray-etcd-test/Chart.yaml
@@ -21,9 +21,23 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-chart-dirs:
-  - charts
-chart-repos:
-  - stable=https://charts.helm.sh/stable
-  - csm-algol60=https://artifactory.algol60.net/artifactory/csm-helm-charts/
-all: true
+apiVersion: v2
+appVersion: 1.0.0
+dependencies:
+- name: cray-service
+  version: "~10.0.0"
+  repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+- name: cray-etcd-base
+  version: "~1.0.0"
+  repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+description: "Test etcd chart"
+home: "https://github.com/Cray-HPE/cray-etcd-test"
+keywords:
+  - cray-etcd-test
+maintainers:
+  - name: bklein
+    email: bradley.klein@hpe.com
+name: cray-etcd-test
+sources:
+  - "https://github.com/Cray-HPE/cray-etcd-test"
+version: 1.0.0

--- a/charts/cray-etcd-test/files/etcd-load.sh
+++ b/charts/cray-etcd-test/files/etcd-load.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Create a file with random text data
+dd if=/dev/urandom bs=1K count=512 | tr -dc 'a-zA-Z0-9' > data
+
+# Load the data into etcd
+for i in {1..8192}; do
+  echo "$i"
+  etcdctl put "key-$i" "$(cat data)"
+done
+
+# Delete the data file
+rm data

--- a/charts/cray-etcd-test/templates/configmap.yaml
+++ b/charts/cray-etcd-test/templates/configmap.yaml
@@ -21,9 +21,12 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-chart-dirs:
-  - charts
-chart-repos:
-  - stable=https://charts.helm.sh/stable
-  - csm-algol60=https://artifactory.algol60.net/artifactory/csm-helm-charts/
-all: true
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cray-etcd-test-config
+  namespace: {{ .Release.Namespace }}
+data:
+  etcd-load.sh: |-
+    {{- .Files.Get "files/etcd-load.sh" | nindent 4 }}

--- a/charts/cray-etcd-test/values.yaml
+++ b/charts/cray-etcd-test/values.yaml
@@ -1,0 +1,86 @@
+cray-service:
+  type: Deployment
+  nameOverride: cray-etcd-test
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/name
+            operator: In
+            values:
+            - cray-etcd-test
+        topologyKey: "kubernetes.io/hostname"
+  replicaCount: 3
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 50%
+    type: RollingUpdate
+  containers:
+    busybox:
+      name: busybox
+      image:
+        repository: artifactory.algol60.net/csm-docker/stable/docker.io/library/busybox
+        tag: 1.28.0-glibc
+      command: ["sleep", "60000"]
+  etcdWaitContainer: true
+cray-etcd-base:
+  nameOverride: cray-etcd-test
+  etcd:
+    image:
+      registry: artifactory.algol60.net
+      repository: csm-docker/stable/docker.io/bitnami/etcd
+      tag: 3.5.9-debian-11-r15-patch
+      debug: true
+    disasterRecovery:
+      cronjob:
+        snapshotsDir: "/snapshots/cray-etcd-test-bitnami-etcd"
+        schedule: "0 */1 * * *"
+        historyLimit: 1
+        snapshotHistoryLimit: 24
+    enabled: true
+    fullnameOverride: "cray-etcd-test-bitnami-etcd"
+    persistence:
+      enabled: true
+      accessModes:
+        - "ReadWriteOnce"
+      size: 4Gi
+    extraEnvVars:
+      - name: ETCD_HEARTBEAT_INTERVAL
+        value: "4200"
+      - name: ETCD_ELECTION_TIMEOUT
+        value: "21000"
+      - name: ETCD_MAX_SNAPSHOTS
+        value: "1"
+      - name: ETCD_QUOTA_BACKEND_BYTES
+        value: "10737418240"
+      - name: ETCD_SNAPSHOT_COUNT
+        value: "5000000"
+      - name: ETCD_SNAPSHOT_HISTORY_LIMIT
+        value: "24"
+      - name: ETCD_DISABLE_PRESTOP
+        value: "yes"
+    autoCompactionMode: revision
+    autoCompactionRetention: "100000"
+    extraVolumeMounts:
+    - name: cray-etcd-test-config
+      mountPath: /usr/local/sbin
+      readOnly: true
+    - name: etcd-config
+      mountPath: /csm
+    extraVolumes:
+    - configMap:
+        defaultMode: 420
+        name: cray-etcd-test-bitnami-etcd-config
+      name: etcd-config
+    - configMap:
+        defaultMode: 0755
+        name: cray-etcd-test-config
+      name: cray-etcd-test-config
+    resources:
+      limits:
+        cpu: 4
+        memory: 8Gi
+      requests:
+        cpu: 10m
+        memory: 64Mi


### PR DESCRIPTION
### Summary and Scope

This change populates the etcd config file with settings specified in extraEnvVars, as etcd does not honor a mix of config file and env var settings.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMINST-6572

### Testing

Mug:

```
ncn-m001:~/brad # kubectl exec -it -n services cray-etcd-test-bitnami-etcd-2 -c etcd -- /bin/bashI have no name!@cray-etcd-test-bitnami-etcd-2:/opt/bitnami/etcd$ cat conf/etcd.yaml
name: cray-etcd-test-bitnami-etcd-2
initial-cluster: "cray-etcd-test-bitnami-etcd-0=http://cray-etcd-test-bitnami-etcd-0.cray-etcd-test-bitnami-etcd-headless.services.svc.cluster.local:2380,cray-etcd-test-bitnami-etcd-1=http://cray-etcd-test-bitnami-etcd-1.cray-etcd-test-bitnami-etcd-headless.services.svc.cluster.local:2380,cray-etcd-test-bitnami-etcd-2=http://cray-etcd-test-bitnami-etcd-2.cray-etcd-test-bitnami-etcd-headless.services.svc.cluster.local:2380"
initial-advertise-peer-urls: http://cray-etcd-test-bitnami-etcd-2.cray-etcd-test-bitnami-etcd-headless.services.svc.cluster.local:2380
listen-peer-urls: http://0.0.0.0:2380
advertise-client-urls: http://cray-etcd-test-bitnami-etcd-2.cray-etcd-test-bitnami-etcd-headless.services.svc.cluster.local:2379
listen-client-urls: http://0.0.0.0:2379
data-dir: /bitnami/etcd/data
disable-prestop: yes
election-timeout: 21000
heartbeat-interval: 4200
max-snapshots: 1
quota-backend-bytes: 10737418240
snapshot-count: 5000000
snapshot-history-limit: 24
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
