### PR TITLE
Update bitnami container images and chart for CSM 1.6 (CASMPET-6758)

### DIFF
--- a/charts/cray-etcd-backup/Chart.yaml
+++ b/charts/cray-etcd-backup/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-etcd-backup
-version: 0.5.4
+version: 0.5.5
 description: Configures etcd cluster backups
 home: https://github.com/Cray-HPE/cray-etcd
 maintainers:
@@ -32,5 +32,5 @@ maintainers:
 annotations:
   artifacthub.io/images: |
     - name: util
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/demisto/boto3py3:kubectl_v1_21_12_1.0.0.43797
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/demisto/boto3py3:pet-utils-csm-1.6
   artifacthub.io/license: MIT

--- a/charts/cray-etcd-backup/values.yaml
+++ b/charts/cray-etcd-backup/values.yaml
@@ -8,7 +8,7 @@ fullnameOverride: ""
 util:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker.io/demisto/boto3py3
-    tag: kubectl_v1_21_12_1.0.0.49259
+    tag: pet-utils-csm-1.6
     pullPolicy: IfNotPresent
 
 crayEtcdBackup:

--- a/charts/cray-etcd-base/Chart.yaml
+++ b/charts/cray-etcd-base/Chart.yaml
@@ -23,21 +23,21 @@
 #
 apiVersion: v2
 name: cray-etcd-base
-version: 1.0.11
+version: 1.1.0
 description: This chart should never be installed directly, instead it is intended to be a sub-chart.
 home: https://github.com/Cray-HPE/cray-etcd
 dependencies:
   - name: etcd
-    version: 8.9.0
+    version: 9.5.6
     repository: https://charts.bitnami.com/bitnami
 maintainers:
   - name: bklei
 annotations:
   artifacthub.io/images: |
     - name: etcd
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/etcd:3.5.9-debian-11-r15-patch
-    - name: bitnami-shell
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/bitnami-shell:11-debian-11-r128
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/etcd:3.5.9-debian-11-r148
+    - name: os-shell
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/os-shell:11-debian-11-r90
     - name: util
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/demisto/boto3py3:kubectl_v1_21_12_1.0.0.43797
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/demisto/boto3py3:pet-utils-csm-1.6
   artifacthub.io/license: MIT

--- a/charts/cray-etcd-base/values.yaml
+++ b/charts/cray-etcd-base/values.yaml
@@ -46,8 +46,8 @@ etcd:
     enabled: true
     image:
       registry: artifactory.algol60.net
-      repository: csm-docker/stable/docker.io/bitnami/bitnami-shell
-      tag: 11-debian-11-r128
+      repository: csm-docker/stable/docker.io/bitnami/os-shell
+      tag: 11-debian-11-r90
       digest: ""
       pullPolicy: IfNotPresent
   containerPorts:
@@ -63,7 +63,7 @@ etcd:
   image:
     registry: artifactory.algol60.net
     repository: csm-docker/stable/docker.io/bitnami/etcd
-    tag: 3.5.9-debian-11-r15-patch
+    tag: 3.5.9-debian-11-r148
     debug: false
   pullPolicy: IfNotPresent
   fullnameOverride: ""
@@ -181,5 +181,5 @@ etcd:
 util:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker.io/demisto/boto3py3
-    tag: kubectl_v1_21_12_1.0.0.49259
+    tag: pet-utils-csm-1.6
     pullPolicy: IfNotPresent

--- a/charts/cray-etcd-defrag/Chart.yaml
+++ b/charts/cray-etcd-defrag/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-etcd-defrag
-version: 0.4.0
+version: 0.4.1
 description: Defrags etcd clusters
 home: https://github.com/Cray-HPE/cray-etcd
 maintainers:
@@ -9,5 +9,5 @@ maintainers:
 annotations:
   artifacthub.io/images: |
     - name: kubectl
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/demisto/boto3py3:kubectl_v1_21_12_1.0.0.49259
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/demisto/boto3py3:pet-utils-csm-1.6
   artifacthub.io/license: MIT

--- a/charts/cray-etcd-defrag/templates/cronjob.yaml
+++ b/charts/cray-etcd-defrag/templates/cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             command:
               - /bin/sh
               - -c
-              - "/scripts/etcd_defrag.sh --defrag all --skip cray-hbtd-etcd"
+              - "/scripts/etcd_defrag.sh --defrag all --skip cray-hbtd-bitnami-etcd"
             volumeMounts:
             - name: etcd-defrag
               mountPath: /scripts

--- a/charts/cray-etcd-defrag/values.yaml
+++ b/charts/cray-etcd-defrag/values.yaml
@@ -8,7 +8,7 @@ fullnameOverride: ""
 kubectl:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker.io/demisto/boto3py3
-    tag: kubectl_v1_21_12_1.0.0.49259
+    tag: pet-utils-csm-1.6
     pullPolicy: IfNotPresent
 
 crayEtcdDefrag:
@@ -17,5 +17,5 @@ crayEtcdDefrag:
 
 crayHbtdEtcdDefrag:
   defragCronSchedule: "0 */4 * * *"
-  etcdClusterName: "cray-hbtd-etcd"
+  etcdClusterName: "cray-hbtd-bitnami-etcd"
   ## This cronjob uses the same image as crayEtcdDefrag

--- a/charts/cray-etcd-test/Chart.yaml
+++ b/charts/cray-etcd-test/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: cray-etcd-test
 sources:
   - "https://github.com/Cray-HPE/cray-etcd-test"
-version: 1.0.0
+version: 1.1.0

--- a/charts/cray-etcd-test/values.yaml
+++ b/charts/cray-etcd-test/values.yaml
@@ -27,11 +27,6 @@ cray-service:
 cray-etcd-base:
   nameOverride: cray-etcd-test
   etcd:
-    image:
-      registry: artifactory.algol60.net
-      repository: csm-docker/stable/docker.io/bitnami/etcd
-      tag: 3.5.9-debian-11-r15-patch
-      debug: true
     disasterRecovery:
       cronjob:
         snapshotsDir: "/snapshots/cray-etcd-test-bitnami-etcd"


### PR DESCRIPTION
### Summary and Scope

Update cray-etcd-base with upstream changes (no more patching upstream image)

### Issues and Related PRs

  * CASMPET-6758: update bitnami-etcd container with upstream merge

### Testing

beau:
```
pod/cray-etcd-test-bitnami-etcd-0                                     2/2     Running     0               58m
pod/cray-etcd-test-bitnami-etcd-1                                     2/2     Running     0               60m
pod/cray-etcd-test-bitnami-etcd-2                                     2/2     Running     0               61m
```

```
ncn-m001:~ # /opt/cray/platform-utils/etcd/etcd-util.sh endpoint_status cray-etcd-test
### cray-etcd-test-bitnami-etcd-1 Endpoint Status: ###
+----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
|    ENDPOINT    |        ID        | VERSION | DB SIZE | IS LEADER | IS LEARNER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS |
+----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
| 127.0.0.1:2379 | 6cf1858af3bb04d9 |   3.5.9 |   20 kB |     false |      false |         6 |       4271 |               4271 |        |
+----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
### cray-etcd-test-bitnami-etcd-0 Endpoint Status: ###
+----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
|    ENDPOINT    |        ID        | VERSION | DB SIZE | IS LEADER | IS LEARNER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS |
+----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
| 127.0.0.1:2379 | ee240103b803de8d |   3.5.9 |   20 kB |     false |      false |         6 |       4271 |               4271 |        |
+----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
### cray-etcd-test-bitnami-etcd-2 Endpoint Status: ###
+----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
|    ENDPOINT    |        ID        | VERSION | DB SIZE | IS LEADER | IS LEARNER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS |
+----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
| 127.0.0.1:2379 | f994b3ba5579b3b6 |   3.5.9 |   20 kB |      true |      false |         6 |       4275 |               4275 |        |
+----------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing

