### PR TITLE
Update cray-etcd-test chart now that cray-etcd-base 1.1.1 has published (CASMPET-6831)

### DIFF
--- a/charts/cray-etcd-test/Chart.yaml
+++ b/charts/cray-etcd-test/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
   version: "~10.0.0"
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 - name: cray-etcd-base
-  version: "~1.1.0"
+  version: "~1.1.1"
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 description: "Test etcd chart"
 home: "https://github.com/Cray-HPE/cray-etcd-test"
@@ -40,4 +40,4 @@ maintainers:
 name: cray-etcd-test
 sources:
   - "https://github.com/Cray-HPE/cray-etcd-test"
-version: 1.1.0
+version: 1.1.1


### PR DESCRIPTION
### Summary and Scope

Fix upgrade issue with bitnami etcd chart (introduction of new label).

### Issues and Related PRs

  * CASMPET-6831: bitnami CSM 1.6 base chart upgrade fails due to immutable statefulset field(s)

### Testing

beau 
```
pit:~/brad # loftsman ship --manifest-path ./manifest-new.yaml --charts-path ./helm
2023-11-01T21:06:27Z INF Initializing the connection to the Kubernetes cluster using KUBECONFIG (system default), and context (current-context) command=ship
2023-11-01T21:06:27Z INF Initializing helm client object command=ship
         |\
         | \
         |  \
         |___\      Shipping your Helm workloads with Loftsman
       \--||___/
  ~~~~~~\_____/~~~~~~~

2023-11-01T21:06:27Z INF Ensuring that the loftsman namespace exists command=ship
2023-11-01T21:06:27Z INF Loftsman will use the packaged charts at ./helm as the Helm install source command=ship
2023-11-01T21:06:27Z INF Running a release for the provided manifest at ./manifest-new.yaml command=ship

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Releasing cray-etcd-test v1.1.1
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

2023-11-01T21:06:27Z INF Running helm install/upgrade with arguments: upgrade --install cray-etcd-test helm/cray-etcd-test-1.1.1.tgz --namespace services --create-namespace --set global.chart.name=cray-etcd-test --set global.chart.version=1.1.1 chart=cray-etcd-test command=ship namespace=services version=1.1.1
2023-11-01T21:07:04Z INF Release "cray-etcd-test" has been upgraded. Happy Helming!
NAME: cray-etcd-test
LAST DEPLOYED: Wed Nov  1 21:06:28 2023
NAMESPACE: services
STATUS: deployed
REVISION: 2
TEST SUITE: None
 chart=cray-etcd-test command=ship namespace=services version=1.1.1
2023-11-01T21:07:04Z INF Ship status: success. Recording status, manifest to configmap loftsman-brad in namespace loftsman command=ship
2023-11-01T21:07:04Z INF Recording log data to configmap loftsman-brad-ship-log in namespace loftsman command=ship
```

```
pit:~/brad # pod=cray-etcd-test-pre-upgrade-etcd-backup-6pq7w

pit:~/brad # kubectl -n services logs $pod -f
Creating /snapshots/cray-etcd-test-bitnami-etcd directory for snapshots...
Changing ownership of /snapshots/cray-etcd-test-bitnami-etcd to etcd user
No resources found in services namespace.
Ensuring cray-etcd-test-bitnami-etcd members have 'app.kubernetes.io/component=etcd' label for bitnami 9.x chart upgrade...
Adding label to cray-etcd-test-bitnami-etcd-0
pod/cray-etcd-test-bitnami-etcd-0 labeled
Adding label to cray-etcd-test-bitnami-etcd-1
pod/cray-etcd-test-bitnami-etcd-1 labeled
Adding label to cray-etcd-test-bitnami-etcd-2
pod/cray-etcd-test-bitnami-etcd-2 labeled
Deleting statefulset for cray-etcd-test-bitnami-etcd allowing helm to recreate
statefulset.apps "cray-etcd-test-bitnami-etcd" deleted
```

```
cray-etcd-test-857cbfdb9f-7gg6j                                   2/2     Running                 0             13m
cray-etcd-test-857cbfdb9f-dxvbk                                   2/2     Running                 0             13m
cray-etcd-test-857cbfdb9f-mswv4                                   2/2     Running                 0             13m
cray-etcd-test-bitnami-etcd-0                                     2/2     Running                 0             2m6s
cray-etcd-test-bitnami-etcd-1                                     2/2     Running                 0             3m16s
cray-etcd-test-bitnami-etcd-2                                     2/2     Running                 0             4m28s
cray-etcd-test-bitnami-etcd-snapshotter-28314540-zmms4            0/2     Completed               0             11m
cray-etcd-test-etcd-post-install-gfck6                            0/1     Completed               0             5m
cray-etcd-test-pre-upgrade-etcd-backup-z7ppf                      0/1     Completed               0             5m11s
cray-etcd-test-wait-for-etcd-2-vwwzl                              0/1     Completed               0             5m1s
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing

