### PR TITLE
Casmpet 6876 release 1.5

### DIFF
--- a/charts/cray-etcd-base/Chart.yaml
+++ b/charts/cray-etcd-base/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-etcd-base
-version: 1.0.11
+version: 1.0.12
 description: This chart should never be installed directly, instead it is intended to be a sub-chart.
 home: https://github.com/Cray-HPE/cray-etcd
 dependencies:

--- a/charts/cray-etcd-base/values.yaml
+++ b/charts/cray-etcd-base/values.yaml
@@ -65,10 +65,14 @@ etcd:
           env_val="$(eval echo \${${env_name}})"
           if [ -n "${env_val}" ]
           then
-              echo "${opt}: ${env_val}"
               if [ -z "$(cat /opt/bitnami/etcd/conf/etcd.yaml | grep ${opt}:)" ]
               then
-                echo "${opt}: ${env_val}" >> /opt/bitnami/etcd/conf/etcd.yaml
+                if [ "${opt}" = "auto-compaction-retention" ]
+                then
+                  echo "${opt}: \"${env_val}\"" >> /opt/bitnami/etcd/conf/etcd.yaml
+                else
+                  echo "${opt}: ${env_val}" >> /opt/bitnami/etcd/conf/etcd.yaml
+                fi
               fi
           fi
       done

--- a/charts/cray-etcd-base/values.yaml
+++ b/charts/cray-etcd-base/values.yaml
@@ -61,18 +61,16 @@ etcd:
       sed -i s/POD_NAME/${MY_POD_NAME}/ /opt/bitnami/etcd/conf/etcd.yaml
       for opt in $(etcd --help 2>&1 | grep '^ *--' | sed -e 's/^ *--//' -e 's/ .*$//')
       do
-          env_name=$(echo ${opt} | sed -e 's/^/ETCD_/' -e 's/-/_/g' | tr [a-z] [A-Z])
-          env_val="$(eval echo \${${env_name}})"
+          env_name=$(echo "${opt}" | sed -e 's/^/ETCD_/' -e 's/-/_/g' | tr '[:lower:]' '[:upper:]')
+          env_val="$(eval echo "\${${env_name}}")"
           if [ -n "${env_val}" ]
           then
-              if [ -z "$(cat /opt/bitnami/etcd/conf/etcd.yaml | grep ${opt}:)" ]
+              if ! grep -q "${opt}:" /opt/bitnami/etcd/conf/etcd.yaml
               then
-                if [ "${opt}" = "auto-compaction-retention" ]
-                then
-                  echo "${opt}: \"${env_val}\"" >> /opt/bitnami/etcd/conf/etcd.yaml
-                else
+                  if [ "${opt}" = auto-compaction-retention ]; then
+                      env_val="\"${env_val}\""
+                  fi
                   echo "${opt}: ${env_val}" >> /opt/bitnami/etcd/conf/etcd.yaml
-                fi
               fi
           fi
       done

--- a/charts/cray-etcd-base/values.yaml
+++ b/charts/cray-etcd-base/values.yaml
@@ -56,7 +56,23 @@ etcd:
   command:
     - "sh"
     - "-c"
-    - "cp /csm/etcd.conf.yml /opt/bitnami/etcd/conf/etcd.yaml; sed -i s/POD_NAME/${MY_POD_NAME}/ /opt/bitnami/etcd/conf/etcd.yaml; /opt/bitnami/scripts/etcd/entrypoint.sh /opt/bitnami/scripts/etcd/run.sh"
+    - |
+      cp /csm/etcd.conf.yml /opt/bitnami/etcd/conf/etcd.yaml
+      sed -i s/POD_NAME/${MY_POD_NAME}/ /opt/bitnami/etcd/conf/etcd.yaml
+      for opt in $(etcd --help 2>&1 | grep '^ *--' | sed -e 's/^ *--//' -e 's/ .*$//')
+      do
+          env_name=$(echo ${opt} | sed -e 's/^/ETCD_/' -e 's/-/_/g' | tr [a-z] [A-Z])
+          env_val="$(eval echo \${${env_name}})"
+          if [ -n "${env_val}" ]
+          then
+              echo "${opt}: ${env_val}"
+              if [ -z "$(cat /opt/bitnami/etcd/conf/etcd.yaml | grep ${opt}:)" ]
+              then
+                echo "${opt}: ${env_val}" >> /opt/bitnami/etcd/conf/etcd.yaml
+              fi
+          fi
+      done
+      /opt/bitnami/scripts/etcd/entrypoint.sh /opt/bitnami/scripts/etcd/run.sh
 
   enabled: true
   clusterDomain: cluster.local


### PR DESCRIPTION
## Summary and Scope

When bitnami-etcd has a configuration file, it ignores all other environment variables that are normally used for etcd configuration. To fix this, this PR puts environment variables into the configuration file. Previously, we had noticed etcd filling up because auto-compaction-retention and auto-compaction-mode were not being set. These variables will now be put in the configuration file and etcd is performing much better.

## Issues and Related PRs

* Resolves [CASMPET-6876](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6876)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * lemondrop by @mjendrysik-hpe 
  * Beau by @leliasen-hpe 

### Test description:

On lemondrop, cray-power-control-bitnami-etcd was deployed with this change that puts the environment variables in the configuration file. It was observed that etcd was in a good state after multiple days of running. Normally, it would have been full after only a couple of days.

On Beau, I deployed a cray-etcd-test chart that had these changes. I observed that it installed successfully and upgraded successfully when upgrading from the previous version of this chart. Note, I did not test an upgrade from the CSM 1.4 version of etcd to this version of bitnami-etcd in CSM 1.5.

## Risk

I did not test an upgrade from CSM 1.4 etcd with an operator to this new version of CSM 1.5 bitnami-etcd. However, I would not expect this change to have any problems during an upgrade.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

