### PR TITLE
CASMPET-6904 update the cert-manager API in etcd-base chart

### DIFF
--- a/charts/cray-etcd-base/Chart.yaml
+++ b/charts/cray-etcd-base/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-etcd-base
-version: 1.1.2
+version: 1.2.0
 description: This chart should never be installed directly, instead it is intended to be a sub-chart.
 home: https://github.com/Cray-HPE/cray-etcd
 dependencies:

--- a/charts/cray-etcd-base/templates/certificates.yaml
+++ b/charts/cray-etcd-base/templates/certificates.yaml
@@ -38,7 +38,7 @@ spec:
   isCA: false
   privateKey:
     size: 2048
-    algorithm: rsa
+    algorithm: RSA
     encoding: PKCS1
   usages:
     - signing
@@ -70,7 +70,7 @@ spec:
   isCA: false
   privateKey:
     size: 2048
-    algorithm: rsa
+    algorithm: RSA
     encoding: PKCS1
   usages:
     - signing
@@ -99,7 +99,7 @@ spec:
   isCA: false
   privateKey:
     size: 2048
-    algorithm: rsa
+    algorithm: RSA
     encoding: PKCS1
   usages:
     - signing

--- a/charts/cray-etcd-base/templates/certificates.yaml
+++ b/charts/cray-etcd-base/templates/certificates.yaml
@@ -33,7 +33,7 @@ spec:
   renewBefore: 24h
   subject:
     organizations:
-    - Cray
+      - Cray
   commonName: "{{ include "cray-etcd-base.fullname" . }}-{{ .Release.Namespace }}-server"
   isCA: false
   privateKey:
@@ -65,7 +65,7 @@ spec:
   renewBefore: 24h
   subject:
     organizations:
-    - Cray
+      - Cray
   commonName: "{{ include "cray-etcd-base.fullname" . }}-{{ .Release.Namespace }}-peer"
   isCA: false
   privateKey:
@@ -94,7 +94,7 @@ spec:
   renewBefore: 24h
   subject:
     organizations:
-    - Cray
+      - Cray
   commonName: "{{ include "cray-etcd-base.fullname" . }}-{{ .Release.Namespace }}-client"
   isCA: false
   privateKey:

--- a/charts/cray-etcd-base/templates/certificates.yaml
+++ b/charts/cray-etcd-base/templates/certificates.yaml
@@ -32,7 +32,7 @@ spec:
   duration: 720h
   renewBefore: 24h
   subject:
-    organization:
+    organizations:
     - Cray
   commonName: "{{ include "cray-etcd-base.fullname" . }}-{{ .Release.Namespace }}-server"
   isCA: false
@@ -64,7 +64,7 @@ spec:
   duration: 720h
   renewBefore: 24h
   subject:
-    organization:
+    organizations:
     - Cray
   commonName: "{{ include "cray-etcd-base.fullname" . }}-{{ .Release.Namespace }}-peer"
   isCA: false
@@ -93,7 +93,7 @@ spec:
   duration: 720h
   renewBefore: 24h
   subject:
-    organization:
+    organizations:
     - Cray
   commonName: "{{ include "cray-etcd-base.fullname" . }}-{{ .Release.Namespace }}-client"
   isCA: false

--- a/charts/cray-etcd-base/templates/certificates.yaml
+++ b/charts/cray-etcd-base/templates/certificates.yaml
@@ -23,7 +23,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 */}}
 {{- if .Values.etcd.auth.client.secureTransport -}}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "{{ include "cray-etcd-base.fullname" . }}-etcd-server-tls"
@@ -31,13 +31,15 @@ spec:
   secretName: "{{ include "cray-etcd-base.fullname" . }}-etcd-server-tls"
   duration: 720h
   renewBefore: 24h
-  organization:
+  subject:
+    organization:
     - Cray
   commonName: "{{ include "cray-etcd-base.fullname" . }}-{{ .Release.Namespace }}-server"
   isCA: false
-  keySize: 2048
-  keyAlgorithm: rsa
-  keyEncoding: pkcs1
+  privateKey:
+    size: 2048
+    algorithm: rsa
+    encoding: PKCS1
   usages:
     - signing
     - key encipherment
@@ -53,7 +55,7 @@ spec:
     name: "{{ .Values.etcd.auth.client.issuer }}"
     kind: Issuer
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "{{ include "cray-etcd-base.fullname" . }}-etcd-peer-tls"
@@ -61,13 +63,15 @@ spec:
   secretName: "{{ include "cray-etcd-base.fullname" . }}-etcd-peer-tls"
   duration: 720h
   renewBefore: 24h
-  organization:
+  subject:
+    organization:
     - Cray
   commonName: "{{ include "cray-etcd-base.fullname" . }}-{{ .Release.Namespace }}-peer"
   isCA: false
-  keySize: 2048
-  keyAlgorithm: rsa
-  keyEncoding: pkcs1
+  privateKey:
+    size: 2048
+    algorithm: rsa
+    encoding: PKCS1
   usages:
     - signing
     - key encipherment
@@ -80,7 +84,7 @@ spec:
     name: "{{ .Values.etcd.auth.client.issuer }}"
     kind: Issuer
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "{{ include "cray-etcd-base.fullname" . }}-etcd-tls"
@@ -88,13 +92,15 @@ spec:
   secretName: "{{ include "cray-etcd-base.fullname" . }}-etcd-tls"
   duration: 720h
   renewBefore: 24h
-  organization:
+  subject:
+    organization:
     - Cray
   commonName: "{{ include "cray-etcd-base.fullname" . }}-{{ .Release.Namespace }}-client"
   isCA: false
-  keySize: 2048
-  keyAlgorithm: rsa
-  keyEncoding: pkcs1
+  privateKey:
+    size: 2048
+    algorithm: rsa
+    encoding: PKCS1
   usages:
     - signing
     - key encipherment

--- a/charts/cray-etcd-test/Chart.yaml
+++ b/charts/cray-etcd-test/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
   version: "~10.0.0"
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 - name: cray-etcd-base
-  version: "1.2.0-20240516152747+0ab88f3"
+  version: "1.2.0-20240516154242+ff2fc0e"
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 description: "Test etcd chart"
 home: "https://github.com/Cray-HPE/cray-etcd-test"

--- a/charts/cray-etcd-test/Chart.yaml
+++ b/charts/cray-etcd-test/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
   version: "~10.0.0"
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 - name: cray-etcd-base
-  version: "~1.2.0"
+  version: "1.2.0-20240516143337+7a5adb9"
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 description: "Test etcd chart"
 home: "https://github.com/Cray-HPE/cray-etcd-test"

--- a/charts/cray-etcd-test/Chart.yaml
+++ b/charts/cray-etcd-test/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
   version: "~10.0.0"
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 - name: cray-etcd-base
-  version: "1.2.0-20240516143337+7a5adb9"
+  version: "1.2.0-20240516150033+c271959"
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 description: "Test etcd chart"
 home: "https://github.com/Cray-HPE/cray-etcd-test"

--- a/charts/cray-etcd-test/Chart.yaml
+++ b/charts/cray-etcd-test/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
   version: "~10.0.0"
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 - name: cray-etcd-base
-  version: "1.2.0-20240516150033+c271959"
+  version: "1.2.0-20240516152747+0ab88f3"
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 description: "Test etcd chart"
 home: "https://github.com/Cray-HPE/cray-etcd-test"

--- a/charts/cray-etcd-test/Chart.yaml
+++ b/charts/cray-etcd-test/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: cray-etcd-test
 sources:
   - "https://github.com/Cray-HPE/cray-etcd-test"
-version: 1.1.1
+version: 1.1.2

--- a/charts/cray-etcd-test/Chart.yaml
+++ b/charts/cray-etcd-test/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
   version: "~10.0.0"
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 - name: cray-etcd-base
-  version: "~1.1.1"
+  version: "~1.2.0"
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 description: "Test etcd chart"
 home: "https://github.com/Cray-HPE/cray-etcd-test"
@@ -40,4 +40,4 @@ maintainers:
 name: cray-etcd-test
 sources:
   - "https://github.com/Cray-HPE/cray-etcd-test"
-version: 1.1.2
+version: 1.2.0

--- a/charts/cray-etcd-test/values.yaml
+++ b/charts/cray-etcd-test/values.yaml
@@ -30,6 +30,7 @@ cray-etcd-base:
     auth:
       client:
         secureTransport: true
+        issuer: "cert-manager-issuer-common"
     disasterRecovery:
       cronjob:
         snapshotsDir: "/snapshots/cray-etcd-test-bitnami-etcd"

--- a/charts/cray-etcd-test/values.yaml
+++ b/charts/cray-etcd-test/values.yaml
@@ -27,6 +27,9 @@ cray-service:
 cray-etcd-base:
   nameOverride: cray-etcd-test
   etcd:
+    auth:
+      client:
+        secureTransport: true
     disasterRecovery:
       cronjob:
         snapshotsDir: "/snapshots/cray-etcd-test-bitnami-etcd"

--- a/charts/cray-etcd-test/values.yaml
+++ b/charts/cray-etcd-test/values.yaml
@@ -31,6 +31,7 @@ cray-etcd-base:
       client:
         secureTransport: true
         issuer: "cert-manager-issuer-common"
+        existingSecret: "cray-etcd-test-bitnami-etcd-jwt-token"
     disasterRecovery:
       cronjob:
         snapshotsDir: "/snapshots/cray-etcd-test-bitnami-etcd"


### PR DESCRIPTION
## Summary and Scope

In CSM 1.6, cert-manger is being upgraded to v1.12.9. This means the cert-manager.io/v1alpha2 api is being removed. Cray-etcd-base chart needs to be updated to use cert-manager.io/v1.

## Testing

I tested deploying the cray-etcd-test chart on Beau.

My initial test, showed that the chart failed to deploy when the API was not updated. This is expected since that API has disappeared.

```
ncn-m001:~ # helm upgrade -n services cray-etcd-test cray-etcd-test-1.0.2-20240516143337+7a5adb9.tgz
Error: UPGRADE FAILED: [resource mapping not found for name: "cray-etcd-test-etcd-server-tls" namespace: "" from "": no matches for kind "Certificate" in version "cert-manager.io/v1alpha2"
```

My second test showed that I had changed the API in the certificate.yaml file incorrectly. The chart failed to deploy when I had written `organization` instead of `organizations`.

```
ncn-m001:~ # helm upgrade -n services cray-etcd-test cray-etcd-test-1.0.2-20240516150033+c271959.tgz.1
Error: UPGRADE FAILED: error validating "": error validating data: ValidationError(Certificate.spec.subject): unknown field "organization" in io.cert-manager.v1.Certificate.spec.subject
```

Finally, the chart deployed successfully showing that the `certificate.yaml` file was correct.

```
ncn-m001:~ # helm install -n services cray-etcd-test cray-etcd-test-1.0.2-20240516154808+1249b76.tgz
NAME: cray-etcd-test
LAST DEPLOYED: Thu May 16 15:50:43 2024
NAMESPACE: services
STATUS: deployed
REVISION: 1
TEST SUITE: None
```

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

