### PR TITLE
CASMPET-7374: Use apiVersion 'batch/v1' in cray-etcd-backup cronjob.yaml template

### DIFF
--- a/charts/cray-etcd-backup/Chart.yaml
+++ b/charts/cray-etcd-backup/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-etcd-backup
-version: 0.5.5
+version: 0.5.6
 description: Configures etcd cluster backups
 home: https://github.com/Cray-HPE/cray-etcd
 maintainers:

--- a/charts/cray-etcd-backup/Chart.yaml
+++ b/charts/cray-etcd-backup/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/charts/cray-etcd-backup/templates/cronjob.yaml
+++ b/charts/cray-etcd-backup/templates/cronjob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: etcd-backup-pvc-snapshots-to-s3


### PR DESCRIPTION

## Summary and Scope

CronJob apiVersion `batch/v1` has been around since k8s 1.21.  CronJob apiVersion `batch/v1beta1` is deprecated in K8s 1.25+.  Use `batch/v1` in prep for K8s upgrade to 1.32.

## Issues and Related PRs

* Resolves [CASMPET-7374](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7374)

## Testing
Was able to successfully install on `molly`:

```
pit:~/studenym/cray-etcd-backup # helm install -n services cray-etcd-backup .
NAME: cray-etcd-backup
LAST DEPLOYED: Thu Feb  6 17:26:25 2025
NAMESPACE: services
STATUS: deployed
REVISION: 1
TEST SUITE: None
pit:~/studenym/cray-etcd-backup # kubectl get pods -n services | grep etcd
etcd-backup-restore-65966cd9f6-mk2mv                     1/1     Running                      0                 17s
etcd-backup-restore-65966cd9f6-xlj2t                     1/1     Running                      0                 17s
kube-etcd-defrag-cray-hbtd-bitnami-etcd-28980960-nb5dx   0/2     Completed                    0                 86m
pit:~/studenym/cray-etcd-backup #

NAME                                                    SCHEDULE      TIMEZONE   SUSPEND   ACTIVE   LAST SCHEDULE   AGE
cronjob.batch/etcd-backup-pvc-snapshots-to-s3           5 */1 * * *   <none>     False     0        <none>          110s
```

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

