### PR TITLE
CASMPET-7538 1.3.0 cray-etcd-base charts don't work with PSP

### DIFF
--- a/charts/cray-etcd-base/Chart.yaml
+++ b/charts/cray-etcd-base/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-etcd-base
-version: 1.3.0
+version: 1.3.1
 description: This chart should never be installed directly, instead it is intended to be a sub-chart.
 home: https://github.com/Cray-HPE/cray-etcd
 dependencies:

--- a/charts/cray-etcd-base/values.yaml
+++ b/charts/cray-etcd-base/values.yaml
@@ -41,6 +41,14 @@ fullnameOverride: ""  # use this if you want to provide a more-complete name for
 # https://github.com/bitnami/charts/tree/main/bitnami/etcd#parameters
 #
 etcd:
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+  # When running with PSP, "seccompProfile" is not allowed to
+  # be set to anything, so to allow charts to run with PSP
+  # this needs to be removed.  This will allow this chart to
+  # be deployed on CSM 1.6.
+  containerSecurityContext:
+    seccompProfile: null
+{{- end}}
   extraVolumeMounts:
   - mountPath: /csm
     name: etcd-config
@@ -143,6 +151,10 @@ etcd:
   disasterRecovery:
     enabled: true
     cronjob:
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+      containerSecurityContext:
+        seccompProfile: null
+{{- end}}
       snapshotsDir: "/snapshots"
       schedule: "0 */1 * * *"
       historyLimit: 1
@@ -213,8 +225,12 @@ etcd:
         allowPrivilegeEscalation: false
         capabilities:
           drop: ["ALL"]
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+        seccompProfile: null
+{{- else -}}
         seccompProfile:
           type: "RuntimeDefault"
+{{- end}}
       nodeSelector: {}
       tolerations: []
       serviceAccountName: ""
@@ -233,6 +249,11 @@ etcd:
       ##     memory: 1024Mi
       ##
       resources: {}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+  preUpgradeJob:
+    containerSecurityContext:
+      seccompProfile: null
+{{- end}}
 
 util:
   image:


### PR DESCRIPTION
## Summary and Scope

The 1.3.x cray-etcd-base chart pulls in a newer version of the upstream bitnami etcd chart, which includes the addition of
```
    containerSecurityContext:
      seccompProfile:
        type: "RuntimeDefault"
```
in several places.  On Kubernetes 1.24, PSP does not allow `seccompProfile` to be set, whereas with PSS it is allowed to be set to a few values, including `RuntimeDefault`.  So on CSM 1.7 with PSS implemented through kyverno, this setting is allowed, but on CSM 1.6 with PSP it is not allowed.

With the `seccompProfile` section conditionally removed when being deployed with PSP, the chart can be used on both CSM 1.7 and CSM 1.6.

## Issues and Related PRs
* Resolves [CASMPET-7438](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7538)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

