### PR TITLE
CASMPET-7548 & CASMPET-7605: use latest etcd 3.5.x images

### DIFF
--- a/charts/cray-etcd-base/Chart.yaml
+++ b/charts/cray-etcd-base/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-etcd-base
-version: 1.3.0
+version: 1.3.1
 description: This chart should never be installed directly, instead it is intended to be a sub-chart.
 home: https://github.com/Cray-HPE/cray-etcd
 dependencies:
@@ -31,13 +31,13 @@ dependencies:
     version: 11.2.3
     repository: https://charts.bitnami.com/bitnami
 maintainers:
-  - name: bklei
+  - name: bo-quan
 annotations:
   artifacthub.io/images: |
     - name: etcd
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/etcd:3.5.21-debian-12-r1
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/etcd:3.5.21-debian-12-r6
     - name: os-shell
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/os-shell:12-debian-12-r40
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/os-shell:12-debian-12-r49
     - name: util
       image: artifactory.algol60.net/csm-docker/stable/docker.io/demisto/boto3py3:pet-utils-csm-1.6
   artifacthub.io/license: MIT

--- a/charts/cray-etcd-base/values.yaml
+++ b/charts/cray-etcd-base/values.yaml
@@ -49,7 +49,7 @@ etcd:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/docker.io/bitnami/os-shell
-      tag: 12-debian-12-r40
+      tag: 12-debian-12-r49
       digest: ""
       pullPolicy: IfNotPresent
   containerPorts:
@@ -83,7 +83,7 @@ etcd:
   image:
     registry: artifactory.algol60.net
     repository: csm-docker/stable/docker.io/bitnami/etcd
-    tag: 3.5.21-debian-12-r1
+    tag: 3.5.21-debian-12-r6
     debug: false
   pullPolicy: IfNotPresent
   fullnameOverride: ""
@@ -181,7 +181,7 @@ etcd:
     allowPrivilegeEscalation: false
   defrag:
     ## @param defrag.enabled Enable automatic defragmentation. This is most effective when paired with auto compaction: consider setting "autoCompactionRetention > 0".
-    ## This is not enabled becasue the defrag cronjob in the cray-etcd-degrag chart takes care of this already.
+    ## This is not enabled because the defrag cronjob in the cray-etcd-defrag chart takes care of this already.
     enabled: false
     cronjob:
       startingDeadlineSeconds: ""

--- a/charts/cray-etcd-test/Chart.yaml
+++ b/charts/cray-etcd-test/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -28,7 +28,7 @@ dependencies:
   version: "~12.0.0"
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 - name: cray-etcd-base
-  version: "1.2.0"
+  version: "~1.3.0"
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 description: "Test etcd chart"
 home: "https://github.com/Cray-HPE/cray-etcd-test"
@@ -40,4 +40,4 @@ maintainers:
 name: cray-etcd-test
 sources:
   - "https://github.com/Cray-HPE/cray-etcd-test"
-version: 1.2.0
+version: 1.3.0


### PR DESCRIPTION
## Summary and Scope

bitnami has published newer etcd and os-shell images for etcd 3.5.x release with fewer CVE counts. This PR integrates the newer images for CSM 1.7.0 release.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7548](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7548)
* Resolves [CASMPET-7605](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7605)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `beau`
  * Local development environment
  * Virtual Shasta

### Test description:

Installed the upgraded cray-etcd-test chart, and confirmed that the newer images didn't introduce any regressions compared with the last images deployed for CSM 1.7.0.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

